### PR TITLE
feat: add support for plural proper nouns in article handling

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,11 @@
 name = "mud_perspective"
 version = "0.1.0"
 edition = "2024"
+description = "A perspective-aware text generation engine for MUDs and interactive fiction."
+license = "MIT OR Apache-2.0"
+repository = "https://github.com/jonathanschaab/mud_perspective"
+keywords = ["mud", "text-generation", "nlp", "template"]
+categories = ["text-processing", "game-development"]
 
 [features]
 default = ["ansi", "mxp", "msp"]

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -17,6 +17,7 @@ impl TemplateCache {
     /// # Arguments
     /// * `capacity` - The maximum number of templates to keep in memory. Once
     ///   exceeded, the least recently used templates are automatically evicted.
+    #[must_use]
     pub fn new(capacity: usize) -> Self {
         Self {
             inner: Cache::builder()

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -1,4 +1,4 @@
-use crate::grammar::{conjugate_verb, get_indefinite_article, resolve_pronoun};
+use crate::grammar::{conjugate_verb, resolve_article, resolve_pronoun};
 use crate::models::RenderContext;
 use unicode_segmentation::UnicodeSegmentation;
 
@@ -279,38 +279,15 @@ impl PerspectiveEngine {
                     };
 
                     // Handle dynamic "a" or "an" injection
-                    if let Some(art) = article
-                        && !is_viewer
-                        && !entity.is_proper_noun_for(ctx.viewer_id)
-                    {
-                        let is_capitalized = art.starts_with(|c: char| c.is_uppercase());
-
-                        if art.eq_ignore_ascii_case("a") || art.eq_ignore_ascii_case("an") {
-                            if entity.is_plural() {
-                                if is_capitalized {
-                                    raw_output.push_str("Some ");
-                                } else {
-                                    raw_output.push_str("some ");
-                                }
-                            } else {
-                                let indefinite = get_indefinite_article(name_str);
-                                if is_capitalized {
-                                    if indefinite == "a" {
-                                        raw_output.push_str("A ");
-                                    } else {
-                                        raw_output.push_str("An ");
-                                    }
-                                } else {
-                                    raw_output.push_str(indefinite);
-                                    raw_output.push(' ');
-                                }
-                            }
-                        } else if art.eq_ignore_ascii_case("the") {
-                            if is_capitalized {
-                                raw_output.push_str("The ");
-                            } else {
-                                raw_output.push_str("the ");
-                            }
+                    if let Some(art) = article {
+                        if let Some(resolved_art) = resolve_article(
+                            art,
+                            name_str,
+                            is_viewer,
+                            entity.is_proper_noun_for(ctx.viewer_id),
+                            entity.is_plural(),
+                        ) {
+                            raw_output.push_str(resolved_art);
                         }
                     }
 

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -281,7 +281,8 @@ impl PerspectiveEngine {
                     // Handle dynamic "a" or "an" injection
                     if let Some(art) = article
                         && !is_viewer
-                        && !entity.is_proper_noun_for(ctx.viewer_id)
+                        && (!entity.is_proper_noun_for(ctx.viewer_id)
+                            || (entity.is_plural() && art.eq_ignore_ascii_case("the")))
                     {
                         let is_capitalized = art.starts_with(|c: char| c.is_uppercase());
 

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -20,7 +20,7 @@ pub enum Token {
     PronounRef {
         /// The key of the entity in the `RenderContext`.
         key: String,
-        /// The type of pronoun requested (e.g., "subj", "obj", "poss", "abs_poss", "reflex").
+        /// The type of pronoun requested (e.g., `"subj"`, `"obj"`, `"poss"`, `"abs_poss"`, `"reflex"`).
         p_type: String,
         /// A flag indicating if the pronoun type was capitalized (e.g. {source:Subj}).
         is_capitalized: bool,
@@ -62,6 +62,11 @@ impl Template {
     ///
     /// # Errors
     /// Returns a `String` describing the syntax error if the template is malformed.
+    ///
+    /// # Panics
+    /// Panics if the string `split` iterator fails to yield at least one item, which is
+    /// technically impossible under standard Rust string split guarantees.
+    #[allow(clippy::too_many_lines)]
     pub fn compile(raw: &str) -> Result<Self, String> {
         let mut tokens = Vec::new();
         let mut chars = raw.char_indices().peekable();
@@ -133,7 +138,7 @@ impl Template {
                             tokens.push(Token::EntityRef {
                                 key: p2.to_lowercase(),
                                 article: Some(p1.to_string()),
-                                is_capitalized: p2.chars().next().is_some_and(|c| c.is_uppercase()),
+                                is_capitalized: p2.chars().next().is_some_and(char::is_uppercase),
                             });
                         } else {
                             if p1.is_empty() || p2.is_empty() {
@@ -146,7 +151,7 @@ impl Template {
                             tokens.push(Token::PronounRef {
                                 key: p1.to_lowercase(),
                                 p_type: p2.to_lowercase(),
-                                is_capitalized: p2.chars().next().is_some_and(|c| c.is_uppercase()),
+                                is_capitalized: p2.chars().next().is_some_and(char::is_uppercase),
                             });
                         }
                     } else {
@@ -161,7 +166,7 @@ impl Template {
                         tokens.push(Token::EntityRef {
                             key: p1.to_lowercase(),
                             article: None,
-                            is_capitalized: p1.chars().next().is_some_and(|c| c.is_uppercase()),
+                            is_capitalized: p1.chars().next().is_some_and(char::is_uppercase),
                         });
                     }
                 } else {
@@ -183,10 +188,8 @@ impl Template {
                     };
 
                     let original_verb = base_verb.to_string();
-                    let is_capitalized = original_verb
-                        .chars()
-                        .next()
-                        .is_some_and(|c| c.is_uppercase());
+                    let is_capitalized =
+                        original_verb.chars().next().is_some_and(char::is_uppercase);
                     let lower_verb = original_verb.to_lowercase();
 
                     if original_verb.is_empty() {
@@ -248,7 +251,7 @@ impl PerspectiveEngine {
                     "Failed to render template: Missing entity for key '{}'",
                     key
                 );
-                format!("Missing entity for key: {}", key)
+                format!("Missing entity for key: {key}")
             })
         };
 
@@ -269,26 +272,25 @@ impl PerspectiveEngine {
 
                     // Capitalize the name if explicitly requested and it isn't already
                     let name_buf;
-                    let name_str = if *is_capitalized
-                        && name.chars().next().is_some_and(|c| c.is_lowercase())
-                    {
-                        name_buf = crate::grammar::capitalize_first(&name);
-                        name_buf.as_str()
-                    } else {
-                        name.as_ref()
-                    };
+                    let name_str =
+                        if *is_capitalized && name.chars().next().is_some_and(char::is_lowercase) {
+                            name_buf = crate::grammar::capitalize_first(&name);
+                            name_buf.as_str()
+                        } else {
+                            name.as_ref()
+                        };
 
                     // Handle dynamic "a" or "an" injection
-                    if let Some(art) = article {
-                        if let Some(resolved_art) = resolve_article(
+                    if let Some(art) = article
+                        && let Some(resolved_art) = resolve_article(
                             art,
                             name_str,
                             is_viewer,
                             entity.is_proper_noun_for(ctx.viewer_id),
                             entity.is_plural(),
-                        ) {
-                            raw_output.push_str(resolved_art);
-                        }
+                        )
+                    {
+                        raw_output.push_str(resolved_art);
                     }
 
                     raw_output.push_str(name_str);
@@ -338,12 +340,12 @@ impl PerspectiveEngine {
         }
 
         // 2. Pass the fully assembled base-case string to the typography post-processor
-        Ok(Self::post_process_typography(raw_output))
+        Ok(Self::post_process_typography(&raw_output))
     }
 
     /// Segments the text by true sentence boundaries and capitalizes the first letter.
-    fn post_process_typography(input: String) -> String {
-        let mut output = String::with_capacity(input.capacity());
+    fn post_process_typography(input: &str) -> String {
+        let mut output = String::with_capacity(input.len());
 
         let mut bounds = input.split_sentence_bound_indices();
         bounds.next(); // Skip the first bound (which is always 0)
@@ -461,10 +463,7 @@ fn consume_until_closed(
 
     if !closed {
         tracing::error!("Unclosed {} starting at index {}", tag_type, start_idx);
-        return Err(format!(
-            "Unclosed {} starting at index {}",
-            tag_type, start_idx
-        ));
+        return Err(format!("Unclosed {tag_type} starting at index {start_idx}"));
     }
 
     Ok(end_idx)
@@ -526,7 +525,7 @@ fn find_skipped_tag_end(remainder: &str) -> Option<usize> {
 #[cold]
 fn validation_error(message: &str, content: &str, open_char: char) -> String {
     let close_char = if open_char == '{' { '}' } else { ']' };
-    let formatted_message = format!("{}: {}{}{}", message, open_char, content, close_char);
+    let formatted_message = format!("{message}: {open_char}{content}{close_char}");
     tracing::error!("{}", formatted_message);
     formatted_message
 }

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -281,22 +281,29 @@ impl PerspectiveEngine {
                     // Handle dynamic "a" or "an" injection
                     if let Some(art) = article
                         && !is_viewer
-                        && (!entity.is_proper_noun_for(ctx.viewer_id)
-                            || (entity.is_plural() && art.eq_ignore_ascii_case("the")))
+                        && !entity.is_proper_noun_for(ctx.viewer_id)
                     {
                         let is_capitalized = art.starts_with(|c: char| c.is_uppercase());
 
                         if art.eq_ignore_ascii_case("a") || art.eq_ignore_ascii_case("an") {
-                            let indefinite = get_indefinite_article(name_str);
-                            if is_capitalized {
-                                if indefinite == "a" {
-                                    raw_output.push_str("A ");
+                            if entity.is_plural() {
+                                if is_capitalized {
+                                    raw_output.push_str("Some ");
                                 } else {
-                                    raw_output.push_str("An ");
+                                    raw_output.push_str("some ");
                                 }
                             } else {
-                                raw_output.push_str(indefinite);
-                                raw_output.push(' ');
+                                let indefinite = get_indefinite_article(name_str);
+                                if is_capitalized {
+                                    if indefinite == "a" {
+                                        raw_output.push_str("A ");
+                                    } else {
+                                        raw_output.push_str("An ");
+                                    }
+                                } else {
+                                    raw_output.push_str(indefinite);
+                                    raw_output.push(' ');
+                                }
                             }
                         } else if art.eq_ignore_ascii_case("the") {
                             if is_capitalized {

--- a/src/grammar.rs
+++ b/src/grammar.rs
@@ -80,6 +80,9 @@ static VIEWER_PLURAL_PRONOUNS: PronounSet = PronounSet {
 };
 
 /// Returns the correct pronoun based on gender, type, and perspective.
+///
+/// # Errors
+/// Returns a `String` error if the provided `p_type` is an unknown or unsupported pronoun case.
 pub fn resolve_pronoun(
     gender: Gender,
     p_type: &str,
@@ -114,6 +117,7 @@ pub fn resolve_pronoun(
 }
 
 /// Conjugates a base verb into the appropriate person and number.
+#[must_use]
 pub fn conjugate_verb<'a>(
     original_verb: &'a str,
     lower_verb: &'a str,
@@ -142,17 +146,17 @@ pub fn conjugate_verb<'a>(
         || lower_verb.ends_with("sh")
         || lower_verb.ends_with(['s', 'x', 'z'])
     {
-        Cow::Owned(format!("{}es", original_verb))
+        Cow::Owned(format!("{original_verb}es"))
     } else if lower_verb.len() > 1 && lower_verb.ends_with('y') && !is_vowel_before_y(lower_verb) {
         let trimmed = &original_verb[..original_verb.len() - 1];
-        Cow::Owned(format!("{}ies", trimmed))
+        Cow::Owned(format!("{trimmed}ies"))
     } else {
-        Cow::Owned(format!("{}s", original_verb))
+        Cow::Owned(format!("{original_verb}s"))
     }
 }
 
 #[inline]
-fn format_verb<'a>(verb: &'a str, is_capitalized: bool) -> Cow<'a, str> {
+fn format_verb(verb: &str, is_capitalized: bool) -> Cow<'_, str> {
     if is_capitalized {
         Cow::Owned(capitalize_first(verb))
     } else {
@@ -161,6 +165,7 @@ fn format_verb<'a>(verb: &'a str, is_capitalized: bool) -> Cow<'a, str> {
 }
 
 /// Capitalizes the first letter of a string slice.
+#[must_use]
 pub fn capitalize_first(s: &str) -> String {
     let mut c = s.chars();
     match c.next() {
@@ -181,10 +186,11 @@ fn is_vowel_before_y(verb: &str) -> bool {
 #[cold]
 fn unknown_pronoun_error(p_type: &str, context: &str) -> String {
     tracing::error!("Unknown pronoun type requested for {}: {}", context, p_type);
-    format!("Unknown pronoun type: {}", p_type)
+    format!("Unknown pronoun type: {p_type}")
 }
 
 /// Dynamically returns "a" or "an" based on the phonetic pronunciation of the following word.
+#[must_use]
 pub fn get_indefinite_article(word: &str) -> &str {
     in_definite::get_a_or_an(word)
 }
@@ -194,6 +200,7 @@ pub fn get_indefinite_article(word: &str) -> &str {
 ///
 /// **Note:** The returned string includes a trailing space (e.g., `"The "`, `"a "`) to ensure
 /// correct formatting when appended directly before the entity name.
+#[must_use]
 pub fn resolve_article(
     article: &str,
     entity_name: &str,
@@ -213,10 +220,10 @@ pub fn resolve_article(
             Some(if is_capitalized { "Some " } else { "some " })
         } else {
             match (is_capitalized, get_indefinite_article(entity_name)) {
-                (true, "a") => Some("A "),
-                (true, _) => Some("An "),
-                (false, "a") => Some("a "),
-                (false, _) => Some("an "),
+                (true, "an") => Some("An "),
+                (false, "an") => Some("an "),
+                (true, _) => Some("A "), // Covers "a" and any unexpected strings
+                (false, _) => Some("a "),
             }
         }
     } else if article.eq_ignore_ascii_case("the") {

--- a/src/grammar.rs
+++ b/src/grammar.rs
@@ -191,6 +191,9 @@ pub fn get_indefinite_article(word: &str) -> &str {
 
 /// Resolves the correct article (definite or indefinite) for an entity.
 /// Automatically handles proper noun suppression, viewer suppression, and plural adaptation.
+///
+/// **Note:** The returned string includes a trailing space (e.g., `"The "`, `"a "`) to ensure
+/// correct formatting when appended directly before the entity name.
 pub fn resolve_article(
     article: &str,
     entity_name: &str,

--- a/src/grammar.rs
+++ b/src/grammar.rs
@@ -188,3 +188,37 @@ fn unknown_pronoun_error(p_type: &str, context: &str) -> String {
 pub fn get_indefinite_article(word: &str) -> &str {
     in_definite::get_a_or_an(word)
 }
+
+/// Resolves the correct article (definite or indefinite) for an entity.
+/// Automatically handles proper noun suppression, viewer suppression, and plural adaptation.
+pub fn resolve_article(
+    article: &str,
+    entity_name: &str,
+    is_viewer: bool,
+    is_proper_noun: bool,
+    is_plural: bool,
+) -> Option<&'static str> {
+    // Suppress articles if the entity is the viewer or a proper noun
+    if is_viewer || is_proper_noun {
+        return None;
+    }
+
+    let is_capitalized = article.starts_with(|c: char| c.is_uppercase());
+
+    if article.eq_ignore_ascii_case("a") || article.eq_ignore_ascii_case("an") {
+        if is_plural {
+            Some(if is_capitalized { "Some " } else { "some " })
+        } else {
+            match (is_capitalized, get_indefinite_article(entity_name)) {
+                (true, "a") => Some("A "),
+                (true, _) => Some("An "),
+                (false, "a") => Some("a "),
+                (false, _) => Some("an "),
+            }
+        }
+    } else if article.eq_ignore_ascii_case("the") {
+        Some(if is_capitalized { "The " } else { "the " })
+    } else {
+        None
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,21 @@
 //! A Rust library designed to handle perspective-aware text generation for MUDs and interactive fiction.
 
 #![deny(missing_docs)]
+#![warn(
+    clippy::pedantic,
+    clippy::cargo,
+    clippy::missing_errors_doc,
+    clippy::missing_panics_doc,
+    clippy::must_use_candidate,
+    clippy::doc_markdown
+)]
+#![allow(
+    // module_name_repetitions will complain if a struct is named `TemplateCache` inside the `cache` module.
+    // It is highly subjective, and usually fine to disable.
+    clippy::module_name_repetitions,
+    // Often unavoidable when relying on third-party crates that use different versions of the same dependency.
+    clippy::multiple_crate_versions
+)]
 
 /// Thread-safe caching for compiled templates.
 pub mod cache;

--- a/src/models.rs
+++ b/src/models.rs
@@ -79,6 +79,7 @@ impl<'a> RenderContext<'a> {
     ///
     /// # Arguments
     /// * `viewer_id` - The string ID of the observing entity.
+    #[must_use]
     pub fn new(viewer_id: &'a str) -> Self {
         Self {
             viewer_id,
@@ -91,6 +92,7 @@ impl<'a> RenderContext<'a> {
     /// # Arguments
     /// * `key` - The string key used inside the template tags (e.g., "target").
     /// * `entity` - A reference to the game object implementing `TemplateEntity`.
+    #[must_use]
     pub fn with_entity(mut self, key: &'a str, entity: &'a dyn TemplateEntity) -> Self {
         self.entities.insert(key, entity);
         self

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -36,6 +36,8 @@ mod tests {
             // If the viewer is a stranger, hide Aldran's real name.
             if viewer_id == "stranger_1" && self.name == "Aldran" {
                 Cow::Borrowed("tall man")
+            } else if viewer_id == "stranger_1" && self.name == "the Avengers" {
+                Cow::Borrowed("masked heroes")
             } else {
                 Cow::Borrowed(&self.name)
             }
@@ -43,7 +45,7 @@ mod tests {
 
         fn is_proper_noun_for(&self, viewer_id: &str) -> bool {
             // If the stranger sees the masked "tall man", it is no longer a proper noun
-            if viewer_id == "stranger_1" && self.name == "Aldran" {
+            if viewer_id == "stranger_1" && (self.name == "Aldran" || self.name == "the Avengers") {
                 false
             } else {
                 self.is_proper_noun
@@ -150,24 +152,83 @@ mod tests {
         assert_eq!(output_the_viewer, "You are here.");
 
         // --- SCENARIO 6: Plural proper nouns (e.g. "The Smiths", "The Avengers") ---
+        // The correct way to handle these is to include "the" in the entity's name
+        // and flag it as a proper noun so the engine doesn't inject redundant articles.
         let avengers = MockEntity {
             id: "mob_2".to_string(),
-            name: "Avengers".to_string(),
+            name: "the Avengers".to_string(),
             gender: Gender::Plural,
             is_plural: true,
             is_proper_noun: true,
         };
 
-        // Indefinite article "a" should STILL be suppressed
+        // Indefinite article "a" is suppressed, leaving the base name "the Avengers" (capitalized by typography)
         let template_a_plural = cache.get_or_compile("{a:source} assemble!").unwrap();
-        let output_a_plural = render_msg!("char_2", &template_a_plural, "source" => &avengers).unwrap();
-        assert_eq!(output_a_plural, "Avengers assemble!");
+        let output_a_plural =
+            render_msg!("char_2", &template_a_plural, "source" => &avengers).unwrap();
+        assert_eq!(output_a_plural, "The Avengers assemble!");
 
-        // Definite article "the" should NOT be suppressed
+        // Definite article "the" is suppressed, leaving the base name "the Avengers"
         let template_the_plural = cache.get_or_compile("{The:source} assemble!").unwrap();
         let output_the_plural =
             render_msg!("char_2", &template_the_plural, "source" => &avengers).unwrap();
         assert_eq!(output_the_plural, "The Avengers assemble!");
+
+        // --- SCENARIO 7: Plural common nouns (e.g. "wolves") ---
+        let wolves = MockEntity {
+            id: "mob_3".to_string(),
+            name: "wolves".to_string(),
+            gender: Gender::Plural,
+            is_plural: true,
+            is_proper_noun: false,
+        };
+
+        // Indefinite article "a" should evaluate to "some" for plural common nouns
+        let template_a_common_plural = cache.get_or_compile("{a:source} howl.").unwrap();
+        let output_a_common_plural =
+            render_msg!("char_2", &template_a_common_plural, "source" => &wolves).unwrap();
+        assert_eq!(output_a_common_plural, "Some wolves howl.");
+
+        // Definite article "the" should NOT be suppressed for plural common nouns
+        let template_the_common_plural = cache.get_or_compile("{The:source} howl.").unwrap();
+        let output_the_common_plural =
+            render_msg!("char_2", &template_the_common_plural, "source" => &wolves).unwrap();
+        assert_eq!(output_the_common_plural, "The wolves howl.");
+    }
+
+    #[test]
+    fn test_disguised_plural_proper_nouns() {
+        let avengers = MockEntity {
+            id: "mob_2".to_string(),
+            name: "the Avengers".to_string(),
+            gender: Gender::Plural,
+            is_plural: true,
+            is_proper_noun: true,
+        };
+
+        let cache = TemplateCache::new(100);
+
+        let template_a = cache.get_or_compile("{a:source} [source:arrive].").unwrap();
+        let template_the = cache
+            .get_or_compile("{the:source} [source:arrive].")
+            .unwrap();
+
+        // 1. Friend's perspective (knows they are The Avengers)
+        let out_friend_a = render_msg!("char_2", &template_a, "source" => &avengers).unwrap();
+        let out_friend_the = render_msg!("char_2", &template_the, "source" => &avengers).unwrap();
+
+        // Suppresses articles natively because they are recognized as a proper noun
+        assert_eq!(out_friend_a, "The Avengers arrive.");
+        assert_eq!(out_friend_the, "The Avengers arrive.");
+
+        // 2. Stranger's perspective (sees "masked heroes")
+        let out_stranger_a = render_msg!("stranger_1", &template_a, "source" => &avengers).unwrap();
+        let out_stranger_the =
+            render_msg!("stranger_1", &template_the, "source" => &avengers).unwrap();
+
+        // Evaluates as a common plural noun, meaning `{a:source}` maps to "Some", and `{the:source}` maps to "The"
+        assert_eq!(out_stranger_a, "Some masked heroes arrive.");
+        assert_eq!(out_stranger_the, "The masked heroes arrive.");
     }
 
     #[test]

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -148,6 +148,26 @@ mod tests {
         let output_the_viewer =
             render_msg!("char_1", &template_the_viewer, "source" => &aldran).unwrap();
         assert_eq!(output_the_viewer, "You are here.");
+
+        // --- SCENARIO 6: Plural proper nouns (e.g. "The Smiths", "The Avengers") ---
+        let avengers = MockEntity {
+            id: "mob_2".to_string(),
+            name: "Avengers".to_string(),
+            gender: Gender::Plural,
+            is_plural: true,
+            is_proper_noun: true,
+        };
+
+        // Indefinite article "a" should STILL be suppressed
+        let template_a_plural = cache.get_or_compile("{a:source} assemble!").unwrap();
+        let output_a_plural = render_msg!("char_2", &template_a_plural, "source" => &avengers).unwrap();
+        assert_eq!(output_a_plural, "Avengers assemble!");
+
+        // Definite article "the" should NOT be suppressed
+        let template_the_plural = cache.get_or_compile("{The:source} assemble!").unwrap();
+        let output_the_plural =
+            render_msg!("char_2", &template_the_plural, "source" => &avengers).unwrap();
+        assert_eq!(output_the_plural, "The Avengers assemble!");
     }
 
     #[test]


### PR DESCRIPTION
This pull request adds project metadata to Cargo.toml and enables a suite of pedantic Clippy lints to improve code quality. The core logic for article resolution has been refactored into a centralized resolve_article function, and post_process_typography was optimized to take a string slice instead of an owned String. Other changes include the use of named format arguments, #[must_use] attributes, and expanded test coverage for plural nouns and perspective-based name resolution.