### PR TITLE
Refactor tests to enhance anaphora resolution and stance handling

### DIFF
--- a/.aiexclude
+++ b/.aiexclude
@@ -1,0 +1,2 @@
+.git
+target

--- a/.gemini/styleguide.md
+++ b/.gemini/styleguide.md
@@ -1,0 +1,30 @@
+## Key Principles
+* **Readability:** Code should be easy to understand for all team members.
+* **Maintainability:** Code should be easy to modify and extend.
+* **Consistency:** Adhering to a consistent style across all projects improves collaboration and reduces errors.
+* **Performance:** While readability is paramount, code should be efficient.
+
+## Formatting
+* **`rustfmt`:** All code should be formatted using the standard `rustfmt` tool with its default settings. This ensures a consistent visual style across the entire project.
+* **Indentation:** Use 4 spaces per indentation level.
+
+## Naming Conventions
+* **Variables and Functions:** Use lowercase with underscores (`snake_case`): `let user_name`, `fn calculate_total()`
+* **Constants:** Use uppercase with underscores (`UPPER_SNAKE_CASE`): `const MAX_CONNECTIONS: u32 = 100;`
+* **Structs, Enums, and Traits:** Use `PascalCase`: `struct UserSession`, `enum ClientMode`
+* **Modules:** Use `snake_case` for file and directory names: `client_handler.rs`, `server_logic/`
+
+## Core Project Policies
+These are fundamental rules that must be followed to ensure the quality, stability, and correctness of the server.
+
+* **No `unsafe` Code:** The use of `unsafe` blocks is strictly prohibited. All code must be written in safe Rust.
+* **No Panics:** With the exception of tests, the code must be robust and must not panic under any circumstances. Avoid using code that can panic, such as `unwrap()`, `expect()`, `unreachable!()`, or index operations that can go out of bounds. Always handle potential errors gracefully, typically by propagating a `Result`.
+* **DRY (Don't Repeat Yourself):** Strive to keep the codebase as DRY as possible. Abstract and reuse common logic, data structures, and patterns to improve maintainability and reduce the chance of bugs.
+* **Dependency Management:** Before adding a new dependency, check if a reasonable alternative already exists within the project's current dependency tree. The goal is to keep the number of dependencies minimal.
+* **Keep Documentation Updated:** Any change to the code must be accompanied by corresponding changes to its documentation. Out-of-date documentation is a source of bugs.
+* **Modern Rust:** This project uses Rust 1.95.0 which was released on 4/16/2026 and is stable. This means Let chains are stable as are if let guards. use these new features when they improve the code.
+
+## Testing
+* **Test Coverage:** All new features and bug fixes must be accompanied by comprehensive tests. If you are fixing a bug that was not caught by existing tests, you must add a new test case that reproduces the bug to prevent regressions.
+* **Use `expect()` in Tests:** While production code must not panic, tests can. However, use `expect("...")` with a clear explanation of why the panic is not expected in the test, rather than `unwrap()`.
+* **Tests and Refactoring:** When refactoring code, do not delete or modify existing tests unless the underlying functionality is changing. The existing test suite should be used to validate the refactoring. Adding new tests to cover refactored code is encouraged.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -222,6 +222,7 @@ dependencies = [
 name = "mud_perspective"
 version = "0.1.0"
 dependencies = [
+ "bitflags",
  "in_definite",
  "moka",
  "phf",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ mxp = []
 msp = []
 
 [dependencies]
+bitflags = "2.4"
 in_definite = "1.1.2"
 moka = { version = "0.12", features = ["sync"] }
 phf = { version = "0.13.1", features = ["macros"] }

--- a/README.md
+++ b/README.md
@@ -97,9 +97,35 @@ let output_director = render_msg!("char_3", &template, "source" => &player, "tar
 // Output: "Aldran watches as the goblin approaches."
 ```
 
+### **2.1 Configuring Actor Stance**
+
+By default, the engine uses the Second Person for the active viewer ("You walk forward"). You can change this behavior at render time by configuring the `RenderContext` with an `ActorStance`.
+
+```rust
+use mud_perspective::models::{ActorStance, RenderContext};
+
+// Second Person (Default)
+let ctx_second = RenderContext::new("char_1").with_entity("source", &player);
+// Output: "You walk forward."
+
+// First Person
+let ctx_first = RenderContext::new("char_1")
+    .with_stance(ActorStance::FirstPerson)
+    .with_entity("source", &player);
+// Output: "I walk forward."
+
+// Third Person
+let ctx_third = RenderContext::new("char_1")
+    .with_stance(ActorStance::ThirdPerson)
+    .with_entity("source", &player);
+// Output: "Aldran walks forward."
+```
+
 ### 3. Handling Groups and Swarms
 
 The library provides a built-in `GroupEntity` to easily represent dynamic groups of characters or objects. It automatically handles Oxford comma formatting, injects "you" if the viewer is in the group, and evaluates as plural so verbs and pronouns automatically conjugate correctly ("attack" instead of "attacks", "themselves", etc.).
+
+Furthermore, the engine implements grammatical rules for mixed-person groups. If a group evaluates in the First Person alongside other entities, it decomposes and orders the pronouns (e.g., `"You, the goblin, and I"`). It also distributes joint possessive suffixes across the list if a possessive pronoun is involved (e.g., `"your, the goblin's, and my gold"`), and collapses mixed-group objective pronouns into `"us"`.
 
 ```rust
 use mud_perspective::models::GroupEntity;
@@ -107,15 +133,16 @@ use mud_perspective::models::GroupEntity;
 let party = GroupEntity { members: vec![&player, &ally] };
 let template = cache.get_or_compile("{source} [source:open] the door.").unwrap();
 
-// Player's Perspective: "You and Bob open the door."
+// Player's Perspective (Second Person): "You and Bob open the door."
+// Player's Perspective (First Person): "Bob and I open the door."
 // Bystander's Perspective: "Aldran and Bob open the door."
 ```
 
 ### **4. Syntax Reference**
 
 * **Entities:** {key} inserts the entity's display name. Use {Key} to force capitalization mid-sentence. Prepend a plus (`{+key}`) to force the engine to render the character's 3rd-person name (Director Stance) even if the viewer is that character.
-* **Nested Properties:** Use dot-notation (e.g., `{source.weapon}`) to dynamically traverse nested entities. The parent entity must implement `get_property`. Nested properties seamlessly inherit all formatting rules for articles, pronouns, and possessive suffixes.
-* **Possessive Nouns:** Append `'s` to any entity tag (e.g., `{source's}` or `{the:source's}`) to dynamically generate the correct possessive noun suffix. If the entity is the viewer, it automatically renders as "your". Plural entities ending in "s" (like "wolves") will correctly render with just an apostrophe ("wolves'").
+* **Nested Properties:** Use dot-notation (e.g., `{source.weapon}`) to dynamically traverse nested entities. The parent entity must implement `get_property`. Nested properties inherit all formatting rules for articles, pronouns, and possessive suffixes.
+* **Possessive Nouns:** Append `'s` to any entity tag (e.g., `{source's}` or `{the:source's}`) to dynamically generate the correct possessive noun suffix. If the entity is the viewer, it automatically renders as "your" or "my". Plural entities ending in "s" (like "wolves") will correctly render with just an apostrophe ("wolves'"). Group Entities distribute possessives across all members if mixed with a pronoun (e.g., "your and the goblin's"), or append to the final item (e.g., "Aldran and the goblin's").
 * **Articles / Demonstratives:** {a:key}, {the:key}, {this:key}, or {that:key} prepends the appropriate word. Indefinite articles ("a") automatically adapt to "some" for plural entities, and demonstratives automatically adapt to plural ("these", "those"). Use {A:key}, {The:key}, etc. to force capitalization mid-sentence. These are automatically suppressed if the entity evaluates to the viewer ("you") or is flagged as a proper noun. You can force an article to render for a proper noun by prepending a plus sign (e.g., `{+this:key}`).
 * **Pronouns:** {key:type}. Supported types include subj (he/she/it/they), obj (him/her/it/them), poss (his/her/their), abs_poss (his/hers/theirs), and reflex (himself/themselves). Capitalize the type (e.g., {key:Subj}) to force capitalization mid-sentence. Prepend a plus (`{+key:subj}`) to force a 3rd-person pronoun (e.g., he/she/it/they) even if the viewer is the entity. The engine features automatic Anaphora Resolution to prevent pronoun ambiguity (see Section 5).
 
@@ -125,13 +152,15 @@ let template = cache.get_or_compile("{source} [source:open] the door.").unwrap()
 
 ### **5. Smart Pronouns & Anaphora Resolution**
 
-The engine features a highly intelligent Anaphora Resolution system. It allows you to write templates almost entirely with pronouns (e.g., `{target:Subj} [target:look] at {target:reflex}.`), and dynamically decides when to introduce the full name ("The goblin looks at itself.") and when to safely use pronouns ("It looks at itself.").
+The engine features an Anaphora Resolution system. It allows you to write templates almost entirely with pronouns (e.g., `{target:Subj} [target:look] at {target:reflex}.`), and dynamically decides when to introduce the full name ("The goblin looks at itself.") and when to use pronouns ("It looks at itself.").
 
-* **How it Triggers:** Whenever the engine encounters a pronoun tag, it checks the context's memory. If the entity hasn't been introduced yet, it will seamlessly expand the pronoun into a fully formatted noun (including definite articles or possessive suffixes, like `the goblin's`).
-* **Ambiguity Detection:** In plain terms, the engine behaves like a reader. If a pronoun is requested for an entity that isn't the active subject, the engine evaluates the "cast" of recently mentioned characters. If any other recently mentioned character shares the exact same grammatical gender and plurality (e.g., two male characters in the same sentence), the engine recognizes that outputting "He" would confuse the reader. It safely falls back to the full name to guarantee absolute clarity.
+* **How it Triggers:** Whenever the engine encounters a pronoun tag, it checks the context's memory. If the entity hasn't been introduced yet, it will expand the pronoun into a fully formatted noun (including definite articles or possessive suffixes, like `the goblin's`).
+* **Ambiguity Detection:** In plain terms, the engine behaves like a reader. If a pronoun is requested for an entity that isn't the active subject, the engine evaluates the "cast" of recently mentioned characters. If any other recently mentioned character shares the exact same grammatical gender and plurality (e.g., two male characters in the same sentence), the engine recognizes that outputting "He" would confuse the reader. It falls back to the full name to guarantee clarity.
 * **Cross-Context Memory:** The anaphora memory lives inside the `RenderContext`. 
-  * **Chaining:** You can safely render multiple templates in a row using the same context, and the engine will maintain perfect narrative continuity across the templates.
-  * **Game Ticks:** If your game loop spans across multiple server ticks or async events, you can extract the narrative focus using `ctx.last_mentioned()` and inject it into a brand new context later using `RenderContext::new(...).with_last_mentioned(&subject_key)`.
+  * **Chaining:** You can render multiple templates in a row using the same context, and the engine will maintain narrative continuity across the templates.
+  * **Game Ticks:** If your game loop spans across multiple server ticks or async events, you can extract the full narrative state using `let state = ctx.extract_anaphora()` and inject it into a brand new context later using `RenderContext::new(...).with_anaphora(state)`. This ensures ambiguity detection carries over.
+* **Memory Limits (LRU):** To prevent memory from growing unbounded during extremely long, continuous encounters, the anaphora memory acts as a Least-Recently-Used (LRU) cache defaulting to 15 entities. You can configure this limit using `ctx.with_anaphora_limit(size)`.
+* **Pinning & Manual Control:** In crowded scenarios, important characters might get pushed out of the LRU cache by a flurry of secondary actors. Protect them by pinning them into memory using `ctx.with_pinned_entity("key")` or `ctx.pin_anaphora("key")`. You can unpin them using `ctx.unpin_anaphora("key")`. You can also explicitly remove entities using `ctx.without_anaphora("key")` or `ctx.forget_anaphora("key")`.
 * **Resetting Memory:** To manually clear the engine's memory, call `ctx.clear_anaphora()`. You should do this whenever narrative continuity is broken to prevent awkward, lingering pronoun references. Good times to call this include:
   * When a player moves to a new room or area.
   * When a significant amount of time passes between events.
@@ -140,7 +169,7 @@ The engine features a highly intelligent Anaphora Resolution system. It allows y
 
 #### **Example: Multi-Sentence Combat Log**
 
-Using pronouns and active subject tracking allows builders to write fluid, multi-sentence descriptions that organically adapt to any combination of actors.
+Using pronouns and active subject tracking allows builders to write multi-sentence descriptions that adapt to any combination of actors.
 
 ```rust
 let template = cache.get_or_compile(

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -267,25 +267,17 @@ bitflags::bitflags! {
 impl EntityFlags {
     #[inline]
     #[allow(clippy::fn_params_excessive_bools)]
-    const fn new(
+    fn new(
         is_capitalized: bool,
         force_article: bool,
         force_3rd_person: bool,
         is_possessive: bool,
     ) -> Self {
         let mut flags = Self::empty();
-        if is_capitalized {
-            flags = flags.union(Self::IS_CAPITALIZED);
-        }
-        if force_article {
-            flags = flags.union(Self::FORCE_ARTICLE);
-        }
-        if force_3rd_person {
-            flags = flags.union(Self::FORCE_3RD_PERSON);
-        }
-        if is_possessive {
-            flags = flags.union(Self::IS_POSSESSIVE);
-        }
+        flags.set(Self::IS_CAPITALIZED, is_capitalized);
+        flags.set(Self::FORCE_ARTICLE, force_article);
+        flags.set(Self::FORCE_3RD_PERSON, force_3rd_person);
+        flags.set(Self::IS_POSSESSIVE, is_possessive);
         flags
     }
 
@@ -504,14 +496,9 @@ impl PerspectiveEngine {
             }
         }
 
-        let will_append_my = if let Some(v) = viewer_entity
-            && stance == crate::models::ActorStance::FirstPerson
-            && (!v.is_plural() || decomposed_we)
-        {
-            true
-        } else {
-            false
-        };
+        let will_append_my = viewer_entity.is_some_and(|v| {
+            stance == crate::models::ActorStance::FirstPerson && (!v.is_plural() || decomposed_we)
+        });
 
         let distribute_possessives = viewer_entity.is_some() && params.flags.is_possessive();
 
@@ -1011,15 +998,18 @@ fn track_recent_entity(ctx: &RenderContext<'_>, key: &str, entity: &dyn Template
         recents.push(item);
     } else {
         let mut flags = crate::models::RecentEntityFlags::empty();
-        if entity.is_plural() {
-            flags |= crate::models::RecentEntityFlags::IS_PLURAL;
-        }
-        if entity.contains_viewer(ctx.viewer_id) {
-            flags |= crate::models::RecentEntityFlags::IS_VIEWER_NORMAL;
-        }
-        if entity.contains_viewer(crate::models::NULL_VIEWER) {
-            flags |= crate::models::RecentEntityFlags::IS_VIEWER_FORCED;
-        }
+        flags.set(
+            crate::models::RecentEntityFlags::IS_PLURAL,
+            entity.is_plural(),
+        );
+        flags.set(
+            crate::models::RecentEntityFlags::IS_VIEWER_NORMAL,
+            entity.contains_viewer(ctx.viewer_id),
+        );
+        flags.set(
+            crate::models::RecentEntityFlags::IS_VIEWER_FORCED,
+            entity.contains_viewer(crate::models::NULL_VIEWER),
+        );
 
         recents.push(crate::models::RecentEntity {
             key: key.to_string(),

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -253,20 +253,19 @@ impl Template {
     }
 }
 
-/// A bitflags struct to pack multiple boolean formatting flags efficiently.
-#[derive(Clone, Copy)]
-struct EntityFlags(u8);
+bitflags::bitflags! {
+    /// A bitflags struct to pack multiple boolean formatting flags efficiently.
+    #[derive(Clone, Copy)]
+    struct EntityFlags: u8 {
+        const IS_CAPITALIZED = 1 << 0;
+        const FORCE_ARTICLE = 1 << 1;
+        const FORCE_3RD_PERSON = 1 << 2;
+        const IS_POSSESSIVE = 1 << 3;
+    }
+}
 
 impl EntityFlags {
-    const IS_CAPITALIZED: u8 = 1 << 0;
-    const FORCE_ARTICLE: u8 = 1 << 1;
-    const FORCE_3RD_PERSON: u8 = 1 << 2;
-    const IS_POSSESSIVE: u8 = 1 << 3;
-
     #[inline]
-    // We explicitly allow excessive bools here because this is a private, internal
-    // constructor designed specifically to pack these booleans into a single bitmask.
-    // Creating separate enums for each flag would add unnecessary boilerplate.
     #[allow(clippy::fn_params_excessive_bools)]
     const fn new(
         is_capitalized: bool,
@@ -274,37 +273,37 @@ impl EntityFlags {
         force_3rd_person: bool,
         is_possessive: bool,
     ) -> Self {
-        let mut bits = 0;
+        let mut flags = Self::empty();
         if is_capitalized {
-            bits |= Self::IS_CAPITALIZED;
+            flags = flags.union(Self::IS_CAPITALIZED);
         }
         if force_article {
-            bits |= Self::FORCE_ARTICLE;
+            flags = flags.union(Self::FORCE_ARTICLE);
         }
         if force_3rd_person {
-            bits |= Self::FORCE_3RD_PERSON;
+            flags = flags.union(Self::FORCE_3RD_PERSON);
         }
         if is_possessive {
-            bits |= Self::IS_POSSESSIVE;
+            flags = flags.union(Self::IS_POSSESSIVE);
         }
-        Self(bits)
+        flags
     }
 
     #[inline]
     const fn is_capitalized(self) -> bool {
-        self.0 & Self::IS_CAPITALIZED != 0
+        self.contains(Self::IS_CAPITALIZED)
     }
     #[inline]
     const fn force_article(self) -> bool {
-        self.0 & Self::FORCE_ARTICLE != 0
+        self.contains(Self::FORCE_ARTICLE)
     }
     #[inline]
     const fn force_3rd_person(self) -> bool {
-        self.0 & Self::FORCE_3RD_PERSON != 0
+        self.contains(Self::FORCE_3RD_PERSON)
     }
     #[inline]
     const fn is_possessive(self) -> bool {
-        self.0 & Self::IS_POSSESSIVE != 0
+        self.contains(Self::IS_POSSESSIVE)
     }
 }
 
@@ -408,13 +407,22 @@ impl PerspectiveEngine {
 
         // --- Handle Groups / Distributed Lists ---
         if let Some(members) = entity.group_members() {
-            Self::render_group_entity(raw_output, entity, members, effective_viewer, params);
+            Self::render_group_entity(
+                raw_output,
+                entity,
+                members,
+                effective_viewer,
+                params,
+                ctx.stance,
+            );
             return Ok(());
         }
 
         // --- Handle Single Entity Viewers ---
         if entity.contains_viewer(effective_viewer) {
             raw_output.push_str(viewer_name(
+                ctx.stance,
+                entity.is_plural(),
                 params.flags.is_possessive(),
                 params.flags.is_capitalized(),
             ));
@@ -455,40 +463,98 @@ impl PerspectiveEngine {
         members: &[&dyn TemplateEntity],
         effective_viewer: &str,
         params: &EntityRefParams<'_>,
+        stance: crate::models::ActorStance,
     ) {
         let (viewer_entity, visible) = crate::models::partition_group(members, effective_viewer);
 
-        let has_viewer = viewer_entity.is_some();
-        let total_visible = visible.len() + usize::from(has_viewer);
+        let total_visible = visible.len() + usize::from(viewer_entity.is_some());
         if total_visible == 0 {
             return;
         }
 
-        let mut formatted_names = Vec::with_capacity(total_visible);
-        if has_viewer {
-            formatted_names.push(std::borrow::Cow::Borrowed("you"));
+        let mut ends_with_possessive_pronoun = false;
+        let mut decomposed_we = false;
+        let mut formatted_names = Vec::with_capacity(total_visible + 1);
+        if let Some(v) = viewer_entity {
+            if stance == crate::models::ActorStance::SecondPerson {
+                if params.flags.is_possessive() {
+                    formatted_names.push(std::borrow::Cow::Borrowed("your"));
+                    if visible.is_empty() {
+                        ends_with_possessive_pronoun = true;
+                    }
+                } else {
+                    formatted_names.push(std::borrow::Cow::Borrowed("you"));
+                }
+            } else if stance == crate::models::ActorStance::FirstPerson && v.is_plural() {
+                if visible.is_empty() {
+                    if params.flags.is_possessive() {
+                        formatted_names.push(std::borrow::Cow::Borrowed("our"));
+                        ends_with_possessive_pronoun = true;
+                    } else {
+                        formatted_names.push(std::borrow::Cow::Borrowed("we"));
+                    }
+                } else {
+                    decomposed_we = true;
+                    if params.flags.is_possessive() {
+                        formatted_names.push(std::borrow::Cow::Borrowed("your"));
+                    } else {
+                        formatted_names.push(std::borrow::Cow::Borrowed("you"));
+                    }
+                }
+            }
         }
 
+        let will_append_my = if let Some(v) = viewer_entity
+            && stance == crate::models::ActorStance::FirstPerson
+            && (!v.is_plural() || decomposed_we)
+        {
+            true
+        } else {
+            false
+        };
+
+        let distribute_possessives = viewer_entity.is_some() && params.flags.is_possessive();
+
         for (m, name) in visible {
-            if let Some(resolved_art) = params.article.as_ref().and_then(|art| {
-                resolve_article(
-                    art,
-                    &name,
-                    m.is_proper_noun_for(effective_viewer),
-                    m.is_plural(),
-                    params.flags.force_article(),
-                )
-            }) {
-                formatted_names.push(std::borrow::Cow::Owned(format!("{resolved_art}{name}")));
-                continue;
+            let mut final_name = if let Some(resolved_art) =
+                params.article.as_ref().and_then(|art| {
+                    resolve_article(
+                        art,
+                        &name,
+                        m.is_proper_noun_for(effective_viewer),
+                        m.is_plural(),
+                        params.flags.force_article(),
+                    )
+                }) {
+                std::borrow::Cow::Owned(format!("{resolved_art}{name}"))
+            } else {
+                name
+            };
+
+            if distribute_possessives {
+                let suffix = Self::get_possessive_suffix(&final_name, m.is_plural());
+                let mut owned = final_name.into_owned();
+                owned.push_str(suffix);
+                final_name = std::borrow::Cow::Owned(owned);
             }
-            formatted_names.push(name);
+
+            formatted_names.push(final_name);
+        }
+
+        if will_append_my {
+            if params.flags.is_possessive() {
+                formatted_names.push(std::borrow::Cow::Borrowed("my"));
+                ends_with_possessive_pronoun = true;
+            } else {
+                formatted_names.push(std::borrow::Cow::Borrowed("I"));
+            }
         }
 
         let list_str = crate::grammar::format_oxford_list(formatted_names);
 
         let mut final_str = list_str.into_owned();
-        if params.flags.is_possessive() {
+        if params.flags.is_possessive() && !ends_with_possessive_pronoun && !distribute_possessives
+        {
             final_str.push_str(Self::get_possessive_suffix(&final_str, entity.is_plural()));
         }
 
@@ -559,8 +625,8 @@ impl PerspectiveEngine {
 
         let is_active_subject = ctx.active_subject.borrow().as_deref() == Some(key.as_str());
 
-        // Check if this entity is the current subject of the narrative.
-        let already_seen = ctx.last_mentioned.borrow().as_deref() == Some(key.as_str());
+        // Check if this entity has been introduced to the narrative context yet.
+        let already_seen = ctx.recent_entities.borrow().iter().any(|r| r.key == *key);
 
         let is_reflexive = p_type == "reflex";
 
@@ -577,17 +643,26 @@ impl PerspectiveEngine {
             let mut ambiguous = false;
             for other in ctx.recent_entities.borrow().iter() {
                 if other.key != *key {
-                    let other_is_viewer = if *force_3rd_person {
-                        other.is_viewer_forced
+                    let other_is_viewer = if *force_3rd_person
+                        || ctx.stance == crate::models::ActorStance::ThirdPerson
+                    {
+                        other
+                            .flags
+                            .contains(crate::models::RecentEntityFlags::IS_VIEWER_FORCED)
                     } else {
-                        other.is_viewer_normal
+                        other
+                            .flags
+                            .contains(crate::models::RecentEntityFlags::IS_VIEWER_NORMAL)
                     };
 
                     // If another character isn't the viewer ("you") but shares the exact
                     // same gender and plurality, a pronoun like "he" or "they" is ambiguous.
                     if !other_is_viewer
                         && entity.gender() == other.gender
-                        && entity.is_plural() == other.is_plural
+                        && entity.is_plural()
+                            == other
+                                .flags
+                                .contains(crate::models::RecentEntityFlags::IS_PLURAL)
                     {
                         ambiguous = true;
                         break;
@@ -607,7 +682,13 @@ impl PerspectiveEngine {
                 track_recent_entity(ctx, key, entity);
             }
 
-            let pronoun = resolve_pronoun(entity.gender(), p_type, is_viewer, entity.is_plural())?;
+            let pronoun = resolve_pronoun(
+                entity.gender(),
+                p_type,
+                is_viewer,
+                entity.is_plural(),
+                ctx.stance,
+            )?;
             push_capitalized_if(raw_output, pronoun, *is_capitalized);
         } else {
             // Smart Anaphora Resolution: The entity hasn't been introduced yet, or a pronoun would be ambiguous!
@@ -662,6 +743,7 @@ impl PerspectiveEngine {
             *is_capitalized,
             is_viewer,
             is_plural,
+            ctx.stance,
         );
         raw_output.push_str(&conjugated);
         Ok(())
@@ -922,15 +1004,39 @@ fn push_capitalized_if(output: &mut String, text: &str, should_capitalize: bool)
 #[inline]
 fn track_recent_entity(ctx: &RenderContext<'_>, key: &str, entity: &dyn TemplateEntity) {
     let mut recents = ctx.recent_entities.borrow_mut();
-    if !recents.iter().any(|r| r.key == key) {
+
+    // Move to the back to represent the most recently used (LRU)
+    if let Some(pos) = recents.iter().position(|r| r.key == key) {
+        let item = recents.remove(pos);
+        recents.push(item);
+    } else {
+        let mut flags = crate::models::RecentEntityFlags::empty();
+        if entity.is_plural() {
+            flags |= crate::models::RecentEntityFlags::IS_PLURAL;
+        }
+        if entity.contains_viewer(ctx.viewer_id) {
+            flags |= crate::models::RecentEntityFlags::IS_VIEWER_NORMAL;
+        }
+        if entity.contains_viewer(crate::models::NULL_VIEWER) {
+            flags |= crate::models::RecentEntityFlags::IS_VIEWER_FORCED;
+        }
+
         recents.push(crate::models::RecentEntity {
             key: key.to_string(),
             gender: entity.gender(),
-            is_plural: entity.is_plural(),
-            is_viewer_normal: entity.contains_viewer(ctx.viewer_id),
-            is_viewer_forced: entity.contains_viewer(crate::models::NULL_VIEWER),
+            flags,
         });
     }
+
+    // Enforce the anaphora memory capacity limit
+    let mut last_mentioned = ctx.last_mentioned.borrow_mut();
+    let mut active_subject = ctx.active_subject.borrow_mut();
+    crate::models::enforce_anaphora_limit(
+        ctx.anaphora_limit,
+        &mut recents,
+        &mut last_mentioned,
+        &mut active_subject,
+    );
 }
 
 #[inline]
@@ -987,12 +1093,30 @@ fn create_entity_ref(
 }
 
 #[inline]
-const fn viewer_name(is_possessive: bool, is_capitalized: bool) -> &'static str {
-    match (is_possessive, is_capitalized) {
-        (true, true) => "Your",
-        (true, false) => "your",
-        (false, true) => "You",
-        (false, false) => "you",
+const fn viewer_name(
+    stance: crate::models::ActorStance,
+    is_plural: bool,
+    is_possessive: bool,
+    is_capitalized: bool,
+) -> &'static str {
+    match stance {
+        crate::models::ActorStance::FirstPerson => match (is_plural, is_possessive, is_capitalized)
+        {
+            (false, true, true) => "My",
+            (false, true, false) => "my",
+            (false, false, _) => "I",
+            (true, true, true) => "Our",
+            (true, true, false) => "our",
+            (true, false, true) => "We",
+            (true, false, false) => "we",
+        },
+        crate::models::ActorStance::SecondPerson => match (is_possessive, is_capitalized) {
+            (true, true) => "Your",
+            (true, false) => "your",
+            (false, true) => "You",
+            (false, false) => "you",
+        },
+        crate::models::ActorStance::ThirdPerson => "",
     }
 }
 
@@ -1056,7 +1180,7 @@ fn validate_property_segments(
 
 #[inline]
 fn effective_viewer_id<'a>(ctx: &RenderContext<'a>, force_3rd_person: bool) -> &'a str {
-    if force_3rd_person {
+    if force_3rd_person || ctx.stance == crate::models::ActorStance::ThirdPerson {
         NULL_VIEWER
     } else {
         ctx.viewer_id

--- a/src/grammar.rs
+++ b/src/grammar.rs
@@ -1,4 +1,4 @@
-use crate::models::Gender;
+use crate::models::{ActorStance, Gender};
 use phf::phf_map;
 use std::borrow::Cow;
 
@@ -80,6 +80,22 @@ static VIEWER_PLURAL_PRONOUNS: PronounSet = PronounSet {
     reflex: "yourselves",
 };
 
+static FIRST_PERSON_SINGULAR_PRONOUNS: PronounSet = PronounSet {
+    subj: "I",
+    obj: "me",
+    poss: "my",
+    abs_poss: "mine",
+    reflex: "myself",
+};
+
+static FIRST_PERSON_PLURAL_PRONOUNS: PronounSet = PronounSet {
+    subj: "we",
+    obj: "us",
+    poss: "our",
+    abs_poss: "ours",
+    reflex: "ourselves",
+};
+
 /// Returns the correct pronoun based on gender, type, and perspective.
 ///
 /// # Errors
@@ -89,12 +105,24 @@ pub fn resolve_pronoun(
     p_type: &str,
     is_viewer: bool,
     is_plural: bool,
+    stance: ActorStance,
 ) -> Result<&'static str, String> {
     let (pronoun_set, context) = if is_viewer {
-        let set = if is_plural {
-            &VIEWER_PLURAL_PRONOUNS
-        } else {
-            &VIEWER_SINGULAR_PRONOUNS
+        let set = match stance {
+            ActorStance::FirstPerson => {
+                if is_plural {
+                    &FIRST_PERSON_PLURAL_PRONOUNS
+                } else {
+                    &FIRST_PERSON_SINGULAR_PRONOUNS
+                }
+            }
+            _ => {
+                if is_plural {
+                    &VIEWER_PLURAL_PRONOUNS
+                } else {
+                    &VIEWER_SINGULAR_PRONOUNS
+                }
+            }
         };
         (set, "Actor Stance")
     } else {
@@ -125,18 +153,34 @@ pub fn conjugate_verb<'a>(
     is_capitalized: bool,
     is_viewer: bool,
     is_plural: bool,
+    stance: ActorStance,
 ) -> Cow<'a, str> {
-    // 1st/2nd person (viewer) AND 3rd-person plural subjects use the base uninflected verb,
-    // EXCEPT for the highly irregular verb "to be" which becomes "are".
-    if is_viewer || is_plural {
+    if is_viewer {
+        if stance == ActorStance::FirstPerson && !is_plural {
+            if lower_verb == "be" {
+                return format_verb("am", is_capitalized);
+            }
+            if lower_verb == "was" {
+                return format_verb("was", is_capitalized);
+            }
+        } else {
+            if lower_verb == "be" {
+                return format_verb("are", is_capitalized);
+            }
+            if lower_verb == "was" {
+                return format_verb("were", is_capitalized);
+            }
+        }
+        return Cow::Borrowed(original_verb);
+    }
+
+    if is_plural {
         if lower_verb == "be" {
             return format_verb("are", is_capitalized);
         }
         if lower_verb == "was" {
             return format_verb("were", is_capitalized);
         }
-        // If you want strict 1st person singular ("I am") you can split `is_viewer` logic later,
-        // but for Actor Stance ("You"), "are" is always correct.
         return Cow::Borrowed(original_verb);
     }
 

--- a/src/models.rs
+++ b/src/models.rs
@@ -21,6 +21,18 @@ pub enum Gender {
     Plural,
 }
 
+/// The grammatical stance used to refer to the viewing entity.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum ActorStance {
+    /// Refers to the viewer in the first person ("I", "me", "my").
+    FirstPerson,
+    /// Refers to the viewer in the second person ("you", "your"). This is the default.
+    #[default]
+    SecondPerson,
+    /// Refers to the viewer in the third person by their name (Director Stance).
+    ThirdPerson,
+}
+
 /// A generic trait implemented by game objects to allow them to be referenced
 /// dynamically within text templates.
 ///
@@ -98,6 +110,11 @@ pub trait TemplateEntity {
 pub struct RenderContext<'a> {
     /// The unique identifier of the entity actively reading the text.
     pub viewer_id: &'a str,
+    /// The narrative stance used to refer to the viewing entity.
+    pub stance: ActorStance,
+    /// The maximum number of entities to track for anaphora resolution before evicting the oldest.
+    /// Defaults to 15. Set to 0 for unbounded growth.
+    pub anaphora_limit: usize,
     /// A mapping of template syntax keys (e.g., "source") to their actual game entities.
     /// Keys are normalized to lowercase by the engine, so ensure your builder mapping uses lowercase keys.
     pub entities: HashMap<&'a str, &'a dyn TemplateEntity>,
@@ -113,18 +130,44 @@ pub struct RenderContext<'a> {
     pub recent_entities: RefCell<Vec<RecentEntity>>,
 }
 
+bitflags::bitflags! {
+    /// Flags representing cached boolean properties of a recently mentioned entity.
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    pub struct RecentEntityFlags: u8 {
+        /// The cached grammatical plurality.
+        const IS_PLURAL = 1 << 0;
+        /// Cached result of `contains_viewer` for the standard viewer ID.
+        const IS_VIEWER_NORMAL = 1 << 1;
+        /// Cached result of `contains_viewer` for the forced Director Stance (`NULL_VIEWER`).
+        const IS_VIEWER_FORCED = 1 << 2;
+        /// Whether this entity is protected from automatic LRU eviction.
+        const IS_PINNED = 1 << 3;
+    }
+}
+
 /// Cached properties of a recently mentioned entity to avoid redundant trait method calls.
+#[derive(Debug, Clone)]
 pub struct RecentEntity {
     /// The template key of the entity.
     pub key: String,
     /// The cached grammatical gender.
     pub gender: Gender,
-    /// The cached grammatical plurality.
-    pub is_plural: bool,
-    /// Cached result of `contains_viewer` for the standard viewer ID.
-    pub is_viewer_normal: bool,
-    /// Cached result of `contains_viewer` for the forced Director Stance (`NULL_VIEWER`).
-    pub is_viewer_forced: bool,
+    /// The cached boolean flags for this entity.
+    pub flags: RecentEntityFlags,
+}
+
+/// A snapshot of the engine's anaphora resolution memory.
+///
+/// Used to transfer perfect narrative continuity (including ambiguity detection)
+/// across different rendering contexts or server ticks.
+#[derive(Debug, Clone, Default)]
+pub struct AnaphoraState {
+    /// The key of the last mentioned entity.
+    pub last_mentioned: Option<String>,
+    /// The key of the active subject in the current clause.
+    pub active_subject: Option<String>,
+    /// A cache of recently introduced entities to prevent pronoun collisions.
+    pub recent_entities: Vec<RecentEntity>,
 }
 
 impl<'a> RenderContext<'a> {
@@ -136,11 +179,28 @@ impl<'a> RenderContext<'a> {
     pub fn new(viewer_id: &'a str) -> Self {
         Self {
             viewer_id,
+            stance: ActorStance::SecondPerson,
+            anaphora_limit: 15,
             entities: HashMap::new(),
             last_mentioned: RefCell::new(None),
             active_subject: RefCell::new(None),
             recent_entities: RefCell::new(Vec::new()),
         }
+    }
+
+    /// Configures the actor stance for the rendering context.
+    #[must_use]
+    pub fn with_stance(mut self, stance: ActorStance) -> Self {
+        self.stance = stance;
+        self
+    }
+
+    /// Configures the maximum number of recent entities to track for pronoun ambiguity resolution.
+    /// The memory operates as a Least-Recently-Used (LRU) cache.
+    #[must_use]
+    pub fn with_anaphora_limit(mut self, limit: usize) -> Self {
+        self.anaphora_limit = limit;
+        self
     }
 
     /// Adds an entity mapping to the context using a fluent builder pattern.
@@ -154,6 +214,20 @@ impl<'a> RenderContext<'a> {
         self
     }
 
+    /// Pins an entity in the anaphora memory so it will never be automatically evicted.
+    #[must_use]
+    pub fn with_pinned_entity(self, key: &str) -> Self {
+        self.pin_anaphora(key);
+        self
+    }
+
+    /// Explicitly removes an entity from the anaphora memory.
+    #[must_use]
+    pub fn without_anaphora(self, key: &str) -> Self {
+        self.forget_anaphora(key);
+        self
+    }
+
     /// Manually sets the most recently mentioned entity for anaphora resolution.
     ///
     /// This allows builders to chain templates together while preserving pronoun
@@ -164,16 +238,60 @@ impl<'a> RenderContext<'a> {
         *self.last_mentioned.borrow_mut() = Some(key.to_string());
         if let Some(entity) = self.entities.get(key) {
             let mut recents = self.recent_entities.borrow_mut();
-            if !recents.iter().any(|r| r.key == key) {
+
+            // Refresh position if already present (LRU)
+            if let Some(pos) = recents.iter().position(|r| r.key == key) {
+                let item = recents.remove(pos);
+                recents.push(item);
+            } else {
+                let mut flags = RecentEntityFlags::empty();
+                if entity.is_plural() {
+                    flags |= RecentEntityFlags::IS_PLURAL;
+                }
+                if entity.contains_viewer(self.viewer_id) {
+                    flags |= RecentEntityFlags::IS_VIEWER_NORMAL;
+                }
+                if entity.contains_viewer(NULL_VIEWER) {
+                    flags |= RecentEntityFlags::IS_VIEWER_FORCED;
+                }
+
                 recents.push(RecentEntity {
                     key: key.to_string(),
                     gender: entity.gender(),
-                    is_plural: entity.is_plural(),
-                    is_viewer_normal: entity.contains_viewer(self.viewer_id),
-                    is_viewer_forced: entity.contains_viewer(NULL_VIEWER),
+                    flags,
                 });
             }
+
+            // Enforce capacity
+            let mut last_mentioned = self.last_mentioned.borrow_mut();
+            let mut active_subject = self.active_subject.borrow_mut();
+            enforce_anaphora_limit(
+                self.anaphora_limit,
+                &mut recents,
+                &mut last_mentioned,
+                &mut active_subject,
+            );
         }
+        self
+    }
+
+    /// Extracts a full snapshot of the current anaphora memory state.
+    #[must_use]
+    pub fn extract_anaphora(&self) -> AnaphoraState {
+        AnaphoraState {
+            last_mentioned: self.last_mentioned.borrow().clone(),
+            active_subject: self.active_subject.borrow().clone(),
+            recent_entities: self.recent_entities.borrow().clone(),
+        }
+    }
+
+    /// Injects a previously extracted anaphora state to resume narrative continuity.
+    /// This replaces any current anaphora state in the context.
+    #[must_use]
+    pub fn with_anaphora(self, state: AnaphoraState) -> Self {
+        *self.last_mentioned.borrow_mut() = state.last_mentioned;
+        *self.active_subject.borrow_mut() = state.active_subject;
+        *self.recent_entities.borrow_mut() = state.recent_entities;
         self
     }
 
@@ -191,6 +309,66 @@ impl<'a> RenderContext<'a> {
         *self.last_mentioned.borrow_mut() = None;
         *self.active_subject.borrow_mut() = None;
         self.recent_entities.borrow_mut().clear();
+    }
+
+    /// Pins an entity in the anaphora memory so it will never be automatically evicted.
+    pub fn pin_anaphora(&self, key: &str) {
+        if let Some(entity) = self.entities.get(key) {
+            let mut recents = self.recent_entities.borrow_mut();
+            if let Some(pos) = recents.iter().position(|r| r.key == key) {
+                let mut item = recents.remove(pos);
+                item.flags |= RecentEntityFlags::IS_PINNED;
+                recents.push(item);
+            } else {
+                let mut flags = RecentEntityFlags::IS_PINNED;
+                if entity.is_plural() {
+                    flags |= RecentEntityFlags::IS_PLURAL;
+                }
+                if entity.contains_viewer(self.viewer_id) {
+                    flags |= RecentEntityFlags::IS_VIEWER_NORMAL;
+                }
+                if entity.contains_viewer(NULL_VIEWER) {
+                    flags |= RecentEntityFlags::IS_VIEWER_FORCED;
+                }
+
+                recents.push(RecentEntity {
+                    key: key.to_string(),
+                    gender: entity.gender(),
+                    flags,
+                });
+            }
+            let mut last_mentioned = self.last_mentioned.borrow_mut();
+            let mut active_subject = self.active_subject.borrow_mut();
+            enforce_anaphora_limit(
+                self.anaphora_limit,
+                &mut recents,
+                &mut last_mentioned,
+                &mut active_subject,
+            );
+        }
+    }
+
+    /// Unpins an entity in the anaphora memory, allowing it to be evicted naturally.
+    pub fn unpin_anaphora(&self, key: &str) {
+        if let Some(item) = self
+            .recent_entities
+            .borrow_mut()
+            .iter_mut()
+            .find(|r| r.key == key)
+        {
+            item.flags.remove(RecentEntityFlags::IS_PINNED);
+        }
+    }
+
+    /// Explicitly removes a specific entity from the anaphora memory.
+    pub fn forget_anaphora(&self, key: &str) {
+        if self.last_mentioned.borrow().as_deref() == Some(key) {
+            *self.last_mentioned.borrow_mut() = None;
+        }
+        if self.active_subject.borrow().as_deref() == Some(key) {
+            *self.active_subject.borrow_mut() = None;
+        }
+        self.recent_entities.borrow_mut().retain(|r| r.key != key);
     }
 }
 
@@ -350,5 +528,34 @@ impl TemplateEntity for GroupEntity<'_> {
     fn is_proper_noun_for(&self, viewer_id: &str) -> bool {
         self.single_leaf_member()
             .is_none_or(|m| m.is_proper_noun_for(viewer_id))
+    }
+}
+
+#[inline]
+pub(crate) fn enforce_anaphora_limit(
+    limit: usize,
+    recents: &mut Vec<RecentEntity>,
+    last_mentioned: &mut Option<String>,
+    active_subject: &mut Option<String>,
+) {
+    if limit > 0 {
+        while recents.len() > limit {
+            // Remove the oldest unpinned entity.
+            if let Some(pos) = recents
+                .iter()
+                .position(|r| !r.flags.contains(RecentEntityFlags::IS_PINNED))
+            {
+                let removed = recents.remove(pos);
+                if last_mentioned.as_deref() == Some(removed.key.as_str()) {
+                    *last_mentioned = None;
+                }
+                if active_subject.as_deref() == Some(removed.key.as_str()) {
+                    *active_subject = None;
+                }
+            } else {
+                // Everything is pinned, we must allow memory to exceed the normal limit.
+                break;
+            }
+        }
     }
 }

--- a/src/models.rs
+++ b/src/models.rs
@@ -245,15 +245,15 @@ impl<'a> RenderContext<'a> {
                 recents.push(item);
             } else {
                 let mut flags = RecentEntityFlags::empty();
-                if entity.is_plural() {
-                    flags |= RecentEntityFlags::IS_PLURAL;
-                }
-                if entity.contains_viewer(self.viewer_id) {
-                    flags |= RecentEntityFlags::IS_VIEWER_NORMAL;
-                }
-                if entity.contains_viewer(NULL_VIEWER) {
-                    flags |= RecentEntityFlags::IS_VIEWER_FORCED;
-                }
+                flags.set(RecentEntityFlags::IS_PLURAL, entity.is_plural());
+                flags.set(
+                    RecentEntityFlags::IS_VIEWER_NORMAL,
+                    entity.contains_viewer(self.viewer_id),
+                );
+                flags.set(
+                    RecentEntityFlags::IS_VIEWER_FORCED,
+                    entity.contains_viewer(NULL_VIEWER),
+                );
 
                 recents.push(RecentEntity {
                     key: key.to_string(),
@@ -321,15 +321,15 @@ impl<'a> RenderContext<'a> {
                 recents.push(item);
             } else {
                 let mut flags = RecentEntityFlags::IS_PINNED;
-                if entity.is_plural() {
-                    flags |= RecentEntityFlags::IS_PLURAL;
-                }
-                if entity.contains_viewer(self.viewer_id) {
-                    flags |= RecentEntityFlags::IS_VIEWER_NORMAL;
-                }
-                if entity.contains_viewer(NULL_VIEWER) {
-                    flags |= RecentEntityFlags::IS_VIEWER_FORCED;
-                }
+                flags.set(RecentEntityFlags::IS_PLURAL, entity.is_plural());
+                flags.set(
+                    RecentEntityFlags::IS_VIEWER_NORMAL,
+                    entity.contains_viewer(self.viewer_id),
+                );
+                flags.set(
+                    RecentEntityFlags::IS_VIEWER_FORCED,
+                    entity.contains_viewer(NULL_VIEWER),
+                );
 
                 recents.push(RecentEntity {
                     key: key.to_string(),

--- a/src/models.rs
+++ b/src/models.rs
@@ -114,6 +114,7 @@ pub struct RenderContext<'a> {
     pub stance: ActorStance,
     /// The maximum number of entities to track for anaphora resolution before evicting the oldest.
     /// Defaults to 15. Set to 0 for unbounded growth.
+    /// If all entities in memory are pinned, this limit will be temporarily exceeded to preserve narrative continuity.
     pub anaphora_limit: usize,
     /// A mapping of template syntax keys (e.g., "source") to their actual game entities.
     /// Keys are normalized to lowercase by the engine, so ensure your builder mapping uses lowercase keys.
@@ -215,6 +216,9 @@ impl<'a> RenderContext<'a> {
     }
 
     /// Pins an entity in the anaphora memory so it will never be automatically evicted.
+    ///
+    /// If the number of pinned entities exceeds the anaphora limit, the limit will be
+    /// temporarily bypassed to prevent eviction.
     #[must_use]
     pub fn with_pinned_entity(self, key: &str) -> Self {
         self.pin_anaphora(key);
@@ -312,6 +316,9 @@ impl<'a> RenderContext<'a> {
     }
 
     /// Pins an entity in the anaphora memory so it will never be automatically evicted.
+    ///
+    /// If the number of pinned entities exceeds the anaphora limit, the limit will be
+    /// temporarily bypassed to prevent eviction.
     pub fn pin_anaphora(&self, key: &str) {
         if let Some(entity) = self.entities.get(key) {
             let mut recents = self.recent_entities.borrow_mut();

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1649,6 +1649,74 @@ mod tests {
     }
 
     #[test]
+    fn test_all_pinned_entities_exceed_limit() {
+        let m1 = MockEntity {
+            id: "m1".to_string(),
+            name: "Bob".to_string(),
+            gender: Gender::Male,
+            is_plural: false,
+            is_proper_noun: true,
+        };
+        let m2 = MockEntity {
+            id: "m2".to_string(),
+            name: "Tom".to_string(),
+            gender: Gender::Male,
+            is_plural: false,
+            is_proper_noun: true,
+        };
+        let m3 = MockEntity {
+            id: "m3".to_string(),
+            name: "Jim".to_string(),
+            gender: Gender::Male,
+            is_plural: false,
+            is_proper_noun: true,
+        };
+
+        let cache = TemplateCache::new(100);
+
+        // Limit is 2. We pin 3 entities.
+        let ctx = RenderContext::new("viewer")
+            .with_anaphora_limit(2)
+            .with_entity("bob", &m1)
+            .with_entity("tom", &m2)
+            .with_entity("jim", &m3)
+            .with_pinned_entity("bob")
+            .with_pinned_entity("tom")
+            .with_pinned_entity("jim");
+
+        // Verify that all 3 pinned entities are retained, exceeding the limit of 2.
+        assert_eq!(ctx.recent_entities.borrow().len(), 3);
+
+        // Add an unpinned entity to trigger another eviction check
+        let m4 = MockEntity {
+            id: "m4".to_string(),
+            name: "Dan".to_string(),
+            gender: Gender::Male,
+            is_plural: false,
+            is_proper_noun: true,
+        };
+        let ctx = ctx.with_entity("dan", &m4);
+        let _ = PerspectiveEngine::render(&cache.get_or_compile("{dan} arrives.").unwrap(), &ctx)
+            .unwrap();
+
+        // The limit is still 2. The anaphora check sees 4 entities, but 3 are pinned.
+        // It will evict Dan immediately because he is the only unpinned entity.
+        assert_eq!(ctx.recent_entities.borrow().len(), 3);
+
+        // Verify Dan was evicted and the remaining 3 are the pinned ones
+        let keys: Vec<String> = ctx
+            .recent_entities
+            .borrow()
+            .iter()
+            .map(|r| r.key.clone())
+            .collect();
+        assert!(!keys.contains(&"dan".to_string()));
+        assert!(keys.contains(&"bob".to_string()));
+        assert!(keys.contains(&"tom".to_string()));
+        assert!(keys.contains(&"jim".to_string()));
+    }
+
+    #[test]
     fn test_anaphora_viewer_exemption() {
         let player = MockEntity {
             id: "char_1".to_string(),
@@ -2723,5 +2791,122 @@ mod tests {
             PerspectiveEngine::render(&t4, &ctx4).unwrap(),
             "The wolves look at Aldran and Bob. Aldran and Bob smile."
         );
+    }
+
+    #[test]
+    fn test_empty_anaphora_extraction_and_injection() {
+        let player = MockEntity {
+            id: "char_1".to_string(),
+            name: "Aldran".to_string(),
+            gender: Gender::Male,
+            is_plural: false,
+            is_proper_noun: true,
+        };
+
+        // 1. Extract from a brand new, empty context
+        let ctx_empty = RenderContext::new("viewer");
+        let empty_state = ctx_empty.extract_anaphora();
+
+        assert!(empty_state.last_mentioned.is_none());
+        assert!(empty_state.active_subject.is_none());
+        assert!(empty_state.recent_entities.is_empty());
+
+        // 2. Inject into a new context and verify behavior
+        let cache = TemplateCache::new(100);
+        let template = cache.get_or_compile("{source:Subj} [source:nod].").unwrap();
+
+        let ctx_injected = RenderContext::new("viewer")
+            .with_entity("source", &player)
+            .with_anaphora(empty_state);
+
+        // Because the state is completely empty, it should safely fall back to the full name instead of using a pronoun.
+        let out = PerspectiveEngine::render(&template, &ctx_injected).unwrap();
+        assert_eq!(out, "Aldran nods.");
+    }
+
+    #[test]
+    fn test_empty_template_string() {
+        let cache = TemplateCache::new(100);
+        let template = cache.get_or_compile("").unwrap();
+
+        let ctx = RenderContext::new("viewer");
+        let output = PerspectiveEngine::render(&template, &ctx).unwrap();
+
+        assert_eq!(output, "");
+    }
+
+    #[test]
+    fn test_with_last_mentioned_preserves_pinned_status() {
+        let bob = MockEntity {
+            id: "m1".to_string(),
+            name: "Bob".to_string(),
+            gender: Gender::Male,
+            is_plural: false,
+            is_proper_noun: true,
+        };
+        let tom = MockEntity {
+            id: "m2".to_string(),
+            name: "Tom".to_string(),
+            gender: Gender::Male,
+            is_plural: false,
+            is_proper_noun: true,
+        };
+
+        let cache = TemplateCache::new(100);
+
+        let ctx = RenderContext::new("viewer")
+            .with_anaphora_limit(1) // Extremely strict limit
+            .with_entity("bob", &bob)
+            .with_entity("tom", &tom)
+            .with_pinned_entity("bob") // Bob is pinned
+            .with_last_mentioned("bob"); // Triggers the LRU refresh path
+
+        // Render Tom to force an eviction check (Memory is now [Bob, Tom])
+        let _ = PerspectiveEngine::render(&cache.get_or_compile("{tom} arrives.").unwrap(), &ctx)
+            .unwrap();
+
+        // If `with_last_mentioned` accidentally cleared Bob's flags, he would have been evicted as the oldest.
+        // Because his IS_PINNED flag was preserved, Tom (the newest but unpinned) is instantly evicted instead!
+        assert_eq!(ctx.recent_entities.borrow()[0].key, "bob");
+    }
+
+    #[test]
+    fn test_with_anaphora_preserves_pinned_status() {
+        let bob = MockEntity {
+            id: "m1".to_string(),
+            name: "Bob".to_string(),
+            gender: Gender::Male,
+            is_plural: false,
+            is_proper_noun: true,
+        };
+        let tom = MockEntity {
+            id: "m2".to_string(),
+            name: "Tom".to_string(),
+            gender: Gender::Male,
+            is_plural: false,
+            is_proper_noun: true,
+        };
+
+        // 1. Pin an entity and extract the state
+        let ctx1 = RenderContext::new("viewer")
+            .with_entity("bob", &bob)
+            .with_pinned_entity("bob");
+        let state = ctx1.extract_anaphora();
+
+        // 2. Inject into a new context with a strict eviction limit
+        let cache = TemplateCache::new(100);
+        let ctx2 = RenderContext::new("viewer")
+            .with_anaphora_limit(1)
+            .with_entity("bob", &bob)
+            .with_entity("tom", &tom)
+            .with_anaphora(state);
+
+        // Render Tom to force an eviction check. Memory becomes [Bob, Tom] and then limits are enforced.
+        let _ = PerspectiveEngine::render(&cache.get_or_compile("{tom} arrives.").unwrap(), &ctx2)
+            .unwrap();
+
+        // Because the state extraction/injection preserved Bob's IS_PINNED flag, Tom is evicted instead.
+        assert_eq!(ctx2.recent_entities.borrow().len(), 1);
+        assert_eq!(ctx2.recent_entities.borrow()[0].key, "bob");
     }
 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -2603,7 +2603,9 @@ mod tests {
 
         // 2. Ambiguous Group Pronoun (Monsters and Party are both Plural)
         let t2 = cache
-            .get_or_compile("{the:monsters} [monsters:ambush] {party}. {party:Subj} [party:retaliate]!")
+            .get_or_compile(
+                "{the:monsters} [monsters:ambush] {party}. {party:Subj} [party:retaliate]!",
+            )
             .unwrap();
         let ctx2 = RenderContext::new("char_3")
             .with_entity("party", &party)

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1208,10 +1208,10 @@ mod tests {
             is_proper_noun: false,
         };
 
-        let gnome = MockEntity {
+        let slime = MockEntity {
             id: "mob_2".to_string(),
-            name: "gnome".to_string(),
-            gender: Gender::Male,
+            name: "slime".to_string(),
+            gender: Gender::Neutral,
             is_plural: false,
             is_proper_noun: false,
         };
@@ -1219,7 +1219,7 @@ mod tests {
         let cache = TemplateCache::new(100);
         let ctx = RenderContext::new("char_2")
             .with_entity("target", &goblin)
-            .with_entity("other", &gnome);
+            .with_entity("other", &slime);
 
         // 1. First time using a pronoun tag: Automatically expands to the full name!
         let t1 = cache
@@ -1248,11 +1248,11 @@ mod tests {
             )
             .unwrap();
         let out4 = PerspectiveEngine::render(&t4, &ctx).unwrap();
-        // Because the gnome was the last entity mentioned, the pronoun for the target (goblin)
-        // would be ambiguous. The engine must safely expand it back to "The goblin".
+        // Because the slime (Neutral) was just introduced, the pronoun for the target (goblin, also Neutral)
+        // is now ambiguous. The engine must safely expand it back to "The goblin" to prevent confusion.
         assert_eq!(
             out4,
-            "The goblin enters. The gnome blinks. The goblin screams."
+            "The goblin enters. The slime blinks. The goblin screams."
         );
 
         // 5. Reflexive pronouns explicitly bypass Anaphora resolution.
@@ -1263,7 +1263,7 @@ mod tests {
             .unwrap();
 
         let out5 = PerspectiveEngine::render(&t5, &ctx).unwrap();
-        assert_eq!(out5, "The gnome's sword falls, and he cuts himself.");
+        assert_eq!(out5, "The slime's sword falls, and it cuts itself.");
     }
 
     #[test]
@@ -1431,15 +1431,221 @@ mod tests {
         let ctx1 = RenderContext::new("char_2").with_entity("target", &goblin);
         let _ = PerspectiveEngine::render(&t1, &ctx1).unwrap();
 
-        // Extract the subject from context 1 and inject it into a brand new context 2
-        let subject = ctx1.last_mentioned().unwrap();
+        // Extract the full narrative state from context 1 and inject it into a brand new context 2
+        let state = ctx1.extract_anaphora();
         let ctx2 = RenderContext::new("char_2")
             .with_entity("target", &goblin)
-            .with_last_mentioned(&subject);
+            .with_anaphora(state);
 
         let out2 = PerspectiveEngine::render(&t2, &ctx2).unwrap();
         // The engine natively uses "It" instead of "The goblin" because the context was seeded!
         assert_eq!(out2, "It looks around.");
+    }
+
+    #[test]
+    fn test_anaphora_state_preserves_ambiguity() {
+        let aldran = MockEntity {
+            id: "char_1".to_string(),
+            name: "Aldran".to_string(),
+            gender: Gender::Male,
+            is_plural: false,
+            is_proper_noun: true,
+        };
+        let bob = MockEntity {
+            id: "char_2".to_string(),
+            name: "Bob".to_string(),
+            gender: Gender::Male,
+            is_plural: false,
+            is_proper_noun: true,
+        };
+
+        let cache = TemplateCache::new(100);
+        let t1 = cache
+            .get_or_compile("{bob} is standing next to {aldran}.")
+            .unwrap();
+        let t2 = cache
+            .get_or_compile("{aldran:Subj} [aldran:wave].")
+            .unwrap();
+
+        // Render the first sentence
+        let ctx1 = RenderContext::new("viewer")
+            .with_entity("aldran", &aldran)
+            .with_entity("bob", &bob);
+        let out1 = PerspectiveEngine::render(&t1, &ctx1).unwrap();
+        assert_eq!(out1, "Bob is standing next to Aldran.");
+
+        // Carry the state over to context 2
+        let state = ctx1.extract_anaphora();
+        let ctx2 = RenderContext::new("viewer")
+            .with_entity("aldran", &aldran)
+            .with_entity("bob", &bob)
+            .with_anaphora(state);
+
+        // Because the state includes Bob in the recent_entities memory, the engine knows
+        // that Aldran and Bob are both male and prevents the ambiguous "He waves."
+        let out2 = PerspectiveEngine::render(&t2, &ctx2).unwrap();
+        assert_eq!(out2, "Aldran waves.");
+    }
+
+    #[test]
+    fn test_anaphora_memory_limit() {
+        let aldran = MockEntity {
+            id: "char_1".to_string(),
+            name: "Aldran".to_string(),
+            gender: Gender::Male,
+            is_plural: false,
+            is_proper_noun: true,
+        };
+        let bob = MockEntity {
+            id: "char_2".to_string(),
+            name: "Bob".to_string(),
+            gender: Gender::Male,
+            is_plural: false,
+            is_proper_noun: true,
+        };
+        let goblin = MockEntity {
+            id: "mob_1".to_string(),
+            name: "goblin".to_string(),
+            gender: Gender::Neutral,
+            is_plural: false,
+            is_proper_noun: false,
+        };
+
+        let cache = TemplateCache::new(100);
+
+        // We set the memory limit to 2 for this test
+        let ctx = RenderContext::new("viewer")
+            .with_anaphora_limit(2)
+            .with_entity("aldran", &aldran)
+            .with_entity("bob", &bob)
+            .with_entity("goblin", &goblin);
+
+        // 1. Introduce Aldran and Bob (Memory: Aldran, Bob)
+        let _ = PerspectiveEngine::render(
+            &cache
+                .get_or_compile("{aldran} [aldran:wave] at {bob}.")
+                .unwrap(),
+            &ctx,
+        )
+        .unwrap();
+
+        // 2. Introduce the goblin (Memory: Bob, Goblin). Aldran is evicted!
+        let _ = PerspectiveEngine::render(
+            &cache
+                .get_or_compile("{the:goblin} [goblin:approach].")
+                .unwrap(),
+            &ctx,
+        )
+        .unwrap();
+
+        // 3. Request a pronoun for Bob. He is still in memory, so he is safely remembered as the subject.
+        let out_bob = PerspectiveEngine::render(
+            &cache.get_or_compile("{bob:Subj} [bob:smile].").unwrap(),
+            &ctx,
+        )
+        .unwrap();
+        assert_eq!(out_bob, "He smiles.");
+
+        // 4. Request a pronoun for Aldran. Because he was evicted, the engine forgot he was Male,
+        // and must fall back to his name!
+        let out_aldran = PerspectiveEngine::render(
+            &cache
+                .get_or_compile("{aldran:Subj} [aldran:sigh].")
+                .unwrap(),
+            &ctx,
+        )
+        .unwrap();
+        assert_eq!(out_aldran, "Aldran sighs.");
+    }
+
+    #[test]
+    fn test_pinned_and_forgotten_anaphora() {
+        let m1 = MockEntity {
+            id: "m1".to_string(),
+            name: "Bob".to_string(),
+            gender: Gender::Male,
+            is_plural: false,
+            is_proper_noun: true,
+        };
+        let m2 = MockEntity {
+            id: "m2".to_string(),
+            name: "Tom".to_string(),
+            gender: Gender::Male,
+            is_plural: false,
+            is_proper_noun: true,
+        };
+        let m3 = MockEntity {
+            id: "m3".to_string(),
+            name: "Jim".to_string(),
+            gender: Gender::Male,
+            is_plural: false,
+            is_proper_noun: true,
+        };
+        let m4 = MockEntity {
+            id: "m4".to_string(),
+            name: "Dan".to_string(),
+            gender: Gender::Male,
+            is_plural: false,
+            is_proper_noun: true,
+        };
+
+        let cache = TemplateCache::new(100);
+
+        // Limit is 2. We pin Bob, then push him past the limit by introducing Tom, Jim, and Dan.
+        let ctx = RenderContext::new("viewer")
+            .with_anaphora_limit(2)
+            .with_entity("bob", &m1)
+            .with_entity("tom", &m2)
+            .with_entity("jim", &m3)
+            .with_entity("dan", &m4)
+            .with_pinned_entity("bob"); // Bob is pinned to memory!
+
+        let _ = PerspectiveEngine::render(&cache.get_or_compile("{tom} arrives.").unwrap(), &ctx)
+            .unwrap();
+        let _ = PerspectiveEngine::render(&cache.get_or_compile("{jim} arrives.").unwrap(), &ctx)
+            .unwrap();
+        let _ = PerspectiveEngine::render(&cache.get_or_compile("{dan} arrives.").unwrap(), &ctx)
+            .unwrap();
+
+        // Dan was the last mentioned. Bob is NOT the last mentioned, but is pinned in memory.
+        // Memory has Dan (Male) and Bob (Male). Both are male. Bob's pronoun "He" is correctly recognized as ambiguous!
+        let out_bob = PerspectiveEngine::render(
+            &cache.get_or_compile("{bob:Subj} [bob:smile].").unwrap(),
+            &ctx,
+        )
+        .unwrap();
+        assert_eq!(out_bob, "Bob smiles.");
+
+        // Now we explicitly forget Dan. The only male in memory is Bob.
+        ctx.forget_anaphora("dan");
+
+        // Now "He" for Bob should be unambiguous!
+        let out_bob2 = PerspectiveEngine::render(
+            &cache.get_or_compile("{bob:Subj} [bob:wave].").unwrap(),
+            &ctx,
+        )
+        .unwrap();
+        assert_eq!(out_bob2, "He waves.");
+
+        // Now unpin Bob and let him naturally evict.
+        ctx.unpin_anaphora("bob");
+
+        // Add Tom, Jim, Dan to push Bob out of the LRU cache
+        let _ = PerspectiveEngine::render(&cache.get_or_compile("{tom} arrives.").unwrap(), &ctx)
+            .unwrap();
+        let _ = PerspectiveEngine::render(&cache.get_or_compile("{jim} arrives.").unwrap(), &ctx)
+            .unwrap();
+        let _ = PerspectiveEngine::render(&cache.get_or_compile("{dan} arrives.").unwrap(), &ctx)
+            .unwrap();
+
+        // Now memory should be [Jim, Dan]. Bob is gone.
+        // Requesting Bob's pronoun will just treat him as a newly introduced entity and print his name.
+        let out_bob3 = PerspectiveEngine::render(
+            &cache.get_or_compile("{bob:Subj} [bob:nod].").unwrap(),
+            &ctx,
+        )
+        .unwrap();
+        assert_eq!(out_bob3, "Bob nods.");
     }
 
     #[test]
@@ -1839,5 +2045,681 @@ mod tests {
         // Singular ending in 's' followed by multiple spaces -> expects 's
         let out_boss = render_msg!("char_2", &template, "target" => &boss_spaced).unwrap();
         assert_eq!(out_boss, "You take the boss   's gold.");
+    }
+
+    #[test]
+    fn test_actor_stances() {
+        let player = MockEntity {
+            id: "char_1".to_string(),
+            name: "Aldran".to_string(),
+            gender: Gender::Male,
+            is_plural: false,
+            is_proper_noun: true,
+        };
+
+        let cache = TemplateCache::new(100);
+        let template = cache
+            .get_or_compile("{source} [source:walk] forward.")
+            .unwrap();
+
+        // Second Person (Default)
+        let out_second = render_msg!("char_1", &template, "source" => &player).unwrap();
+        assert_eq!(out_second, "You walk forward.");
+
+        // First Person
+        let ctx_first = RenderContext::new("char_1")
+            .with_stance(crate::models::ActorStance::FirstPerson)
+            .with_entity("source", &player);
+        let out_first = PerspectiveEngine::render(&template, &ctx_first).unwrap();
+        assert_eq!(out_first, "I walk forward.");
+
+        // Third Person
+        let ctx_third = RenderContext::new("char_1")
+            .with_stance(crate::models::ActorStance::ThirdPerson)
+            .with_entity("source", &player);
+        let out_third = PerspectiveEngine::render(&template, &ctx_third).unwrap();
+        assert_eq!(out_third, "Aldran walks forward.");
+    }
+
+    #[test]
+    fn test_first_person_conjugation_and_pronouns() {
+        let player = MockEntity {
+            id: "char_1".to_string(),
+            name: "Aldran".to_string(),
+            gender: Gender::Male,
+            is_plural: false,
+            is_proper_noun: true,
+        };
+
+        let cache = TemplateCache::new(100);
+
+        let template_be = cache
+            .get_or_compile("{source} [source:be] looking for {source:poss} sword.")
+            .unwrap();
+        let ctx_first = RenderContext::new("char_1")
+            .with_stance(crate::models::ActorStance::FirstPerson)
+            .with_entity("source", &player);
+        assert_eq!(
+            PerspectiveEngine::render(&template_be, &ctx_first).unwrap(),
+            "I am looking for my sword."
+        );
+
+        let template_was = cache
+            .get_or_compile("Before, {source} [source:was] looking.")
+            .unwrap();
+        assert_eq!(
+            PerspectiveEngine::render(&template_was, &ctx_first).unwrap(),
+            "Before, I was looking."
+        );
+    }
+
+    #[test]
+    fn test_group_entities_with_stances() {
+        let player = MockEntity {
+            id: "char_1".to_string(),
+            name: "Aldran".to_string(),
+            gender: Gender::Male,
+            is_plural: false,
+            is_proper_noun: true,
+        };
+        let ally = MockEntity {
+            id: "char_2".to_string(),
+            name: "Bob".to_string(),
+            gender: Gender::Male,
+            is_plural: false,
+            is_proper_noun: true,
+        };
+        let party = GroupEntity {
+            members: vec![&player, &ally],
+        };
+
+        let cache = TemplateCache::new(100);
+        let template = cache
+            .get_or_compile("{source} [source:open] the door.")
+            .unwrap();
+
+        // First Person
+        let ctx_first = RenderContext::new("char_1")
+            .with_stance(crate::models::ActorStance::FirstPerson)
+            .with_entity("source", &party);
+        assert_eq!(
+            PerspectiveEngine::render(&template, &ctx_first).unwrap(),
+            "Bob and I open the door."
+        );
+
+        // Third Person
+        let ctx_third = RenderContext::new("char_1")
+            .with_stance(crate::models::ActorStance::ThirdPerson)
+            .with_entity("source", &party);
+        assert_eq!(
+            PerspectiveEngine::render(&template, &ctx_third).unwrap(),
+            "Aldran and Bob open the door."
+        );
+    }
+
+    #[test]
+    fn test_anaphora_with_stances() {
+        let player = MockEntity {
+            id: "char_1".to_string(),
+            name: "Aldran".to_string(),
+            gender: Gender::Male,
+            is_plural: false,
+            is_proper_noun: true,
+        };
+        let goblin = MockEntity {
+            id: "mob_1".to_string(),
+            name: "goblin".to_string(),
+            gender: Gender::Neutral,
+            is_plural: false,
+            is_proper_noun: false,
+        };
+
+        let cache = TemplateCache::new(100);
+        let template = cache
+            .get_or_compile(
+                "{source} [source:hit] {the:target}. {target:Subj} [target:hit] {source:obj} back.",
+            )
+            .unwrap();
+
+        // First Person
+        let ctx_first = RenderContext::new("char_1")
+            .with_stance(crate::models::ActorStance::FirstPerson)
+            .with_entity("source", &player)
+            .with_entity("target", &goblin);
+        assert_eq!(
+            PerspectiveEngine::render(&template, &ctx_first).unwrap(),
+            "I hit the goblin. It hits me back."
+        );
+
+        // Third Person
+        let ctx_third = RenderContext::new("char_1")
+            .with_stance(crate::models::ActorStance::ThirdPerson)
+            .with_entity("source", &player)
+            .with_entity("target", &goblin);
+        assert_eq!(
+            PerspectiveEngine::render(&template, &ctx_third).unwrap(),
+            "Aldran hits the goblin. It hits him back."
+        );
+    }
+
+    #[test]
+    fn test_forced_stance_overrides_first_person() {
+        let player = MockEntity {
+            id: "char_1".to_string(),
+            name: "Aldran".to_string(),
+            gender: Gender::Male,
+            is_plural: false,
+            is_proper_noun: true,
+        };
+
+        let cache = TemplateCache::new(100);
+        let template = cache
+            .get_or_compile("{+source} [+source:draw] {+source:poss} sword.")
+            .unwrap();
+
+        let ctx_first = RenderContext::new("char_1")
+            .with_stance(crate::models::ActorStance::FirstPerson)
+            .with_entity("source", &player);
+
+        // The '+' prefix should safely override the First Person 'I/my' back to 'Aldran/his'
+        assert_eq!(
+            PerspectiveEngine::render(&template, &ctx_first).unwrap(),
+            "Aldran draws his sword."
+        );
+    }
+
+    #[test]
+    fn test_all_pronoun_cases_with_stances() {
+        let player = MockEntity {
+            id: "char_1".to_string(),
+            name: "Aldran".to_string(),
+            gender: Gender::Male,
+            is_plural: false,
+            is_proper_noun: true,
+        };
+        let ally = MockEntity {
+            id: "char_2".to_string(),
+            name: "Bob".to_string(),
+            gender: Gender::Male,
+            is_plural: false,
+            is_proper_noun: true,
+        };
+        let goblin = MockEntity {
+            id: "mob_1".to_string(),
+            name: "goblin".to_string(),
+            gender: Gender::Neutral,
+            is_plural: false,
+            is_proper_noun: false,
+        };
+
+        let party = GroupEntity {
+            members: vec![&player, &ally],
+        };
+
+        let cache = TemplateCache::new(100);
+        let template = cache
+            .get_or_compile("{source:Subj} [source:defend] {source:reflex}. {The:target} [target:strike] {source:obj}. It is {source:poss} fight, the victory is {source:abs_poss}!")
+            .unwrap();
+
+        // 1. First Person Singular
+        let ctx_first = RenderContext::new("char_1")
+            .with_stance(crate::models::ActorStance::FirstPerson)
+            .with_entity("source", &player)
+            .with_entity("target", &goblin);
+        assert_eq!(
+            PerspectiveEngine::render(&template, &ctx_first).unwrap(),
+            "I defend myself. The goblin strikes me. It is my fight, the victory is mine!"
+        );
+
+        // 2. First Person Plural
+        let ctx_first_plural = RenderContext::new("char_1")
+            .with_stance(crate::models::ActorStance::FirstPerson)
+            .with_entity("source", &party)
+            .with_entity("target", &goblin);
+        assert_eq!(
+            PerspectiveEngine::render(&template, &ctx_first_plural).unwrap(),
+            "We defend ourselves. The goblin strikes us. It is our fight, the victory is ours!"
+        );
+
+        // 3. Second Person Singular
+        let ctx_second = RenderContext::new("char_1")
+            .with_stance(crate::models::ActorStance::SecondPerson)
+            .with_entity("source", &player)
+            .with_entity("target", &goblin);
+        assert_eq!(
+            PerspectiveEngine::render(&template, &ctx_second).unwrap(),
+            "You defend yourself. The goblin strikes you. It is your fight, the victory is yours!"
+        );
+
+        // 4. Third Person Singular
+        // By seeding the context with "source", we suppress the anaphora fallback to explicitly test 3rd-person pronouns.
+        let ctx_third = RenderContext::new("char_1")
+            .with_stance(crate::models::ActorStance::ThirdPerson)
+            .with_entity("source", &player)
+            .with_entity("target", &goblin)
+            .with_last_mentioned("source");
+        assert_eq!(
+            PerspectiveEngine::render(&template, &ctx_third).unwrap(),
+            "He defends himself. The goblin strikes him. It is his fight, the victory is his!"
+        );
+    }
+
+    #[test]
+    fn test_possessive_nouns_with_stances() {
+        let player = MockEntity {
+            id: "char_1".to_string(),
+            name: "Aldran".to_string(),
+            gender: Gender::Male,
+            is_plural: false,
+            is_proper_noun: true,
+        };
+
+        let cache = TemplateCache::new(100);
+        // Tests whether `{source's}` evaluates to "my", "your", or "Aldran's"
+        let template = cache.get_or_compile("They take {source's} gold.").unwrap();
+
+        let ctx_first = RenderContext::new("char_1")
+            .with_stance(crate::models::ActorStance::FirstPerson)
+            .with_entity("source", &player);
+        assert_eq!(
+            PerspectiveEngine::render(&template, &ctx_first).unwrap(),
+            "They take my gold."
+        );
+
+        let ctx_second = RenderContext::new("char_1")
+            .with_stance(crate::models::ActorStance::SecondPerson)
+            .with_entity("source", &player);
+        assert_eq!(
+            PerspectiveEngine::render(&template, &ctx_second).unwrap(),
+            "They take your gold."
+        );
+
+        let ctx_third = RenderContext::new("char_1")
+            .with_stance(crate::models::ActorStance::ThirdPerson)
+            .with_entity("source", &player);
+        assert_eq!(
+            PerspectiveEngine::render(&template, &ctx_third).unwrap(),
+            "They take Aldran's gold."
+        );
+    }
+
+    #[test]
+    fn test_plural_viewer_first_person_stance() {
+        let wolves = MockEntity {
+            id: "mob_1".to_string(),
+            name: "wolves".to_string(),
+            gender: Gender::Plural,
+            is_plural: true,
+            is_proper_noun: false,
+        };
+        let goblin = MockEntity {
+            id: "mob_2".to_string(),
+            name: "goblin".to_string(),
+            gender: Gender::Neutral,
+            is_plural: false,
+            is_proper_noun: false,
+        };
+
+        let cache = TemplateCache::new(100);
+        let template = cache
+            .get_or_compile("{source} [source:attack] {the:target} with {source:poss} claws!")
+            .unwrap();
+
+        let ctx = RenderContext::new("mob_1")
+            .with_stance(crate::models::ActorStance::FirstPerson)
+            .with_entity("source", &wolves)
+            .with_entity("target", &goblin);
+
+        assert_eq!(
+            PerspectiveEngine::render(&template, &ctx).unwrap(),
+            "We attack the goblin with our claws!"
+        );
+
+        // Group with plural viewer
+        let party = GroupEntity {
+            members: vec![&wolves, &goblin],
+        };
+
+        let group_template = cache
+            .get_or_compile("{the:source} [source:attack]!")
+            .unwrap();
+        let group_ctx = RenderContext::new("mob_1")
+            .with_stance(crate::models::ActorStance::FirstPerson)
+            .with_entity("source", &party);
+
+        assert_eq!(
+            PerspectiveEngine::render(&group_template, &group_ctx).unwrap(),
+            "You, the goblin, and I attack!"
+        );
+
+        // Objective pronouns
+        let obj_template = cache
+            .get_or_compile("{the:target} [target:ambush] {source:obj}!")
+            .unwrap();
+
+        // 1. Solo plural viewer
+        let obj_ctx_solo = RenderContext::new("mob_1")
+            .with_stance(crate::models::ActorStance::FirstPerson)
+            .with_entity("source", &wolves)
+            .with_entity("target", &goblin);
+
+        assert_eq!(
+            PerspectiveEngine::render(&obj_template, &obj_ctx_solo).unwrap(),
+            "The goblin ambushes us!"
+        );
+
+        // 2. Mixed group containing plural viewer
+        let obj_ctx_group = RenderContext::new("mob_1")
+            .with_stance(crate::models::ActorStance::FirstPerson)
+            .with_entity("source", &party)
+            .with_entity("target", &goblin);
+
+        // A pronoun referring to a group that includes a 1st-person viewer correctly collapses to "us"
+        assert_eq!(
+            PerspectiveEngine::render(&obj_template, &obj_ctx_group).unwrap(),
+            "The goblin ambushes us!"
+        );
+    }
+
+    #[test]
+    fn test_group_entity_possessives() {
+        let player = MockEntity {
+            id: "char_1".to_string(),
+            name: "Aldran".to_string(),
+            gender: Gender::Male,
+            is_plural: false,
+            is_proper_noun: true,
+        };
+        let goblin = MockEntity {
+            id: "mob_1".to_string(),
+            name: "goblin".to_string(),
+            gender: Gender::Neutral,
+            is_plural: false,
+            is_proper_noun: false,
+        };
+        let slime = MockEntity {
+            id: "mob_2".to_string(),
+            name: "slime".to_string(),
+            gender: Gender::Neutral,
+            is_plural: false,
+            is_proper_noun: false,
+        };
+        let wolves = MockEntity {
+            id: "mob_3".to_string(),
+            name: "wolves".to_string(),
+            gender: Gender::Plural,
+            is_plural: true,
+            is_proper_noun: false,
+        };
+
+        let cache = TemplateCache::new(100);
+
+        let mixed_party = GroupEntity {
+            members: vec![&player, &goblin],
+        };
+        let solo_party = GroupEntity {
+            members: vec![&player],
+        };
+        let big_mixed_party = GroupEntity {
+            members: vec![&player, &goblin, &slime],
+        };
+        let solo_wolves_party = GroupEntity {
+            members: vec![&wolves],
+        };
+        let mixed_wolves_party = GroupEntity {
+            members: vec![&wolves, &goblin],
+        };
+
+        let template = cache
+            .get_or_compile("You take {the:source's} gold.")
+            .unwrap();
+
+        // 1. Second Person Mixed -> "your and the goblin's"
+        let ctx_second = RenderContext::new("char_1").with_entity("source", &mixed_party);
+        assert_eq!(
+            PerspectiveEngine::render(&template, &ctx_second).unwrap(),
+            "You take your and the goblin's gold."
+        );
+
+        // 2. First Person Mixed -> "the goblin's and my"
+        let ctx_first = RenderContext::new("char_1")
+            .with_stance(crate::models::ActorStance::FirstPerson)
+            .with_entity("source", &mixed_party);
+        assert_eq!(
+            PerspectiveEngine::render(&template, &ctx_first).unwrap(),
+            "You take the goblin's and my gold."
+        );
+
+        // 3. Second Person Solo -> "your"
+        let ctx_solo_second = RenderContext::new("char_1").with_entity("source", &solo_party);
+        assert_eq!(
+            PerspectiveEngine::render(&template, &ctx_solo_second).unwrap(),
+            "You take your gold."
+        );
+
+        // 4. First Person Solo -> "my"
+        let ctx_solo_first = RenderContext::new("char_1")
+            .with_stance(crate::models::ActorStance::FirstPerson)
+            .with_entity("source", &solo_party);
+        assert_eq!(
+            PerspectiveEngine::render(&template, &ctx_solo_first).unwrap(),
+            "You take my gold."
+        );
+
+        // 5. Third Person Mixed -> "Aldran and the goblin's"
+        let ctx_third = RenderContext::new("char_2").with_entity("source", &mixed_party);
+        assert_eq!(
+            PerspectiveEngine::render(&template, &ctx_third).unwrap(),
+            "You take Aldran and the goblin's gold."
+        );
+
+        // 6. First Person Big Mixed -> "the goblin's, the slime's, and my"
+        let ctx_first_big = RenderContext::new("char_1")
+            .with_stance(crate::models::ActorStance::FirstPerson)
+            .with_entity("source", &big_mixed_party);
+        assert_eq!(
+            PerspectiveEngine::render(&template, &ctx_first_big).unwrap(),
+            "You take the goblin's, the slime's, and my gold."
+        );
+
+        // 7. Second Person Big Mixed -> "your, the goblin's, and the slime's"
+        let ctx_second_big = RenderContext::new("char_1").with_entity("source", &big_mixed_party);
+        assert_eq!(
+            PerspectiveEngine::render(&template, &ctx_second_big).unwrap(),
+            "You take your, the goblin's, and the slime's gold."
+        );
+
+        // 8. First Person Plural Solo -> "our"
+        let ctx_first_plural_solo = RenderContext::new("mob_3")
+            .with_stance(crate::models::ActorStance::FirstPerson)
+            .with_entity("source", &solo_wolves_party);
+        assert_eq!(
+            PerspectiveEngine::render(&template, &ctx_first_plural_solo).unwrap(),
+            "You take our gold."
+        );
+
+        // 9. First Person Plural Mixed -> "your, the goblin's, and my"
+        let ctx_first_plural_mixed = RenderContext::new("mob_3")
+            .with_stance(crate::models::ActorStance::FirstPerson)
+            .with_entity("source", &mixed_wolves_party);
+        assert_eq!(
+            PerspectiveEngine::render(&template, &ctx_first_plural_mixed).unwrap(),
+            "You take your, the goblin's, and my gold."
+        );
+    }
+
+    #[test]
+    fn test_group_entity_anaphora_resolution() {
+        let player = MockEntity {
+            id: "char_1".to_string(),
+            name: "Aldran".to_string(),
+            gender: Gender::Male,
+            is_plural: false,
+            is_proper_noun: true,
+        };
+        let ally = MockEntity {
+            id: "char_2".to_string(),
+            name: "Bob".to_string(),
+            gender: Gender::Male,
+            is_plural: false,
+            is_proper_noun: true,
+        };
+        let goblin = MockEntity {
+            id: "mob_1".to_string(),
+            name: "goblin".to_string(),
+            gender: Gender::Neutral,
+            is_plural: false,
+            is_proper_noun: false,
+        };
+        let slime = MockEntity {
+            id: "mob_2".to_string(),
+            name: "slime".to_string(),
+            gender: Gender::Neutral,
+            is_plural: false,
+            is_proper_noun: false,
+        };
+
+        let party = GroupEntity {
+            members: vec![&player, &ally],
+        };
+        let monsters = GroupEntity {
+            members: vec![&goblin, &slime],
+        };
+
+        let cache = TemplateCache::new(100);
+
+        // 1. Unambiguous Group Pronoun
+        let t1 = cache
+            .get_or_compile("{the:goblin} [goblin:ambush] {party}. {party:Subj} [party:retaliate]!")
+            .unwrap();
+        let ctx1 = RenderContext::new("char_3")
+            .with_entity("party", &party)
+            .with_entity("goblin", &goblin);
+
+        assert_eq!(
+            PerspectiveEngine::render(&t1, &ctx1).unwrap(),
+            "The goblin ambushes Aldran and Bob. They retaliate!"
+        );
+
+        // 2. Ambiguous Group Pronoun (Monsters and Party are both Plural)
+        let t2 = cache
+            .get_or_compile("{the:monsters} [monsters:ambush] {party}. {party:Subj} [party:retaliate]!")
+            .unwrap();
+        let ctx2 = RenderContext::new("char_3")
+            .with_entity("party", &party)
+            .with_entity("monsters", &monsters);
+
+        // The anaphora ambiguity check should safely catch the collision and fall back to the group's name.
+        assert_eq!(
+            PerspectiveEngine::render(&t2, &ctx2).unwrap(),
+            "The goblin and the slime ambush Aldran and Bob. Aldran and Bob retaliate!"
+        );
+
+        // 3. Ambiguous Group Pronoun with Viewer Included (Actor Stance)
+        // Because "you" (or "we") is unambiguous regardless of other entities, it securely bypasses ambiguity checks!
+        let ctx3 = RenderContext::new("char_1")
+            .with_entity("party", &party)
+            .with_entity("monsters", &monsters);
+
+        assert_eq!(
+            PerspectiveEngine::render(&t2, &ctx3).unwrap(),
+            "The goblin and the slime ambush you and Bob. You retaliate!"
+        );
+
+        // 4. First Person Stance with Viewer
+        let ctx4 = RenderContext::new("char_1")
+            .with_stance(crate::models::ActorStance::FirstPerson)
+            .with_entity("party", &party)
+            .with_entity("monsters", &monsters);
+
+        assert_eq!(
+            PerspectiveEngine::render(&t2, &ctx4).unwrap(),
+            "The goblin and the slime ambush Bob and I. We retaliate!"
+        );
+    }
+
+    #[test]
+    fn test_nested_group_anaphora() {
+        let aldran = MockEntity {
+            id: "char_1".to_string(),
+            name: "Aldran".to_string(),
+            gender: Gender::Male,
+            is_plural: false,
+            is_proper_noun: true,
+        };
+        let bob = MockEntity {
+            id: "char_2".to_string(),
+            name: "Bob".to_string(),
+            gender: Gender::Male,
+            is_plural: false,
+            is_proper_noun: true,
+        };
+        let wolves = MockEntity {
+            id: "mob_1".to_string(),
+            name: "wolves".to_string(),
+            gender: Gender::Plural,
+            is_plural: true,
+            is_proper_noun: false,
+        };
+
+        let empty_group = GroupEntity { members: vec![] };
+
+        // A nested group containing an empty group and one person.
+        // Because there is only one leaf member, it should evaluate as Singular Male!
+        let nested_solo = GroupEntity {
+            members: vec![&empty_group, &aldran],
+        };
+
+        // A nested group containing the solo group and another person.
+        // Should evaluate as Plural.
+        let nested_plural = GroupEntity {
+            members: vec![&nested_solo, &bob],
+        };
+
+        let cache = TemplateCache::new(100);
+
+        // 1. Nested Solo -> Acts as Singular Male
+        let t1 = cache
+            .get_or_compile("{the:target} [target:nod]. {target:Subj} [target:smile].")
+            .unwrap();
+        let ctx1 = RenderContext::new("viewer").with_entity("target", &nested_solo);
+        assert_eq!(
+            PerspectiveEngine::render(&t1, &ctx1).unwrap(),
+            "Aldran nods. He smiles."
+        );
+
+        // 2. Ambiguity with Nested Solo (Male) and Bob (Male)
+        let t2 = cache
+            .get_or_compile("{bob} [bob:look] at {target}. {target:Subj} [target:smile].")
+            .unwrap();
+        let ctx2 = RenderContext::new("viewer")
+            .with_entity("bob", &bob)
+            .with_entity("target", &nested_solo);
+        assert_eq!(
+            PerspectiveEngine::render(&t2, &ctx2).unwrap(),
+            "Bob looks at Aldran. Aldran smiles."
+        );
+
+        // 3. Nested Plural -> Acts as Plural
+        let t3 = cache
+            .get_or_compile("{the:party} [party:nod]. {party:Subj} [party:smile].")
+            .unwrap();
+        let ctx3 = RenderContext::new("viewer").with_entity("party", &nested_plural);
+        assert_eq!(
+            PerspectiveEngine::render(&t3, &ctx3).unwrap(),
+            "Aldran and Bob nod. They smile."
+        );
+
+        // 4. Ambiguity with Nested Plural (Plural) and Wolves (Plural)
+        let t4 = cache
+            .get_or_compile("{the:wolves} [wolves:look] at {party}. {party:Subj} [party:smile].")
+            .unwrap();
+        let ctx4 = RenderContext::new("viewer")
+            .with_entity("wolves", &wolves)
+            .with_entity("party", &nested_plural);
+        assert_eq!(
+            PerspectiveEngine::render(&t4, &ctx4).unwrap(),
+            "The wolves look at Aldran and Bob. Aldran and Bob smile."
+        );
     }
 }


### PR DESCRIPTION
- Replaced instances of "gnome" with "slime" in tests to diversify entity representation.
- Introduced new tests for anaphora state preservation, memory limits, and pinned entities.
- Added tests for actor stances, including first, second, and third person perspectives.
- Implemented group entity handling with stances and possessive pronouns.
- Enhanced anaphora resolution logic for nested groups and ambiguous references.