### PR TITLE
Add comprehensive tests for target resolution in combat scenarios

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -60,6 +60,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
+name = "deunicode"
+version = "1.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "abd57806937c9cc163efc8ea3910e00a62e2aeb0b8119f1793a978088f8f6b04"
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -244,6 +250,7 @@ version = "0.1.0"
 dependencies = [
  "arc-swap",
  "bitflags",
+ "deunicode",
  "in_definite",
  "moka",
  "phf",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ msp = []
 [dependencies]
 arc-swap = "1.9.1"
 bitflags = "2.4"
-deunicode = "1.4"
+deunicode = "1.6.2"
 in_definite = "1.1.2"
 moka = { version = "0.12", features = ["sync"] }
 phf = { version = "0.13.1", features = ["macros"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ msp = []
 [dependencies]
 arc-swap = "1.9.1"
 bitflags = "2.4"
+deunicode = "1.4"
 in_definite = "1.1.2"
 moka = { version = "0.12", features = ["sync"] }
 phf = { version = "0.13.1", features = ["macros"] }

--- a/README.md
+++ b/README.md
@@ -313,6 +313,51 @@ let template = cache.get_or_compile(
 // "Bob kicks Aldran in the chest. Aldran stumbles backward, and Bob presses the advantage!"
 ```
 
+### **6. Target Resolution**
+
+The `RenderContext` now provides a built-in `resolve_target` API to map natural language player commands (like "attack him", "steal Aldran's sword", or "look at the second wolf") back to game entities using the context's active anaphora and ordinal memory.
+
+```rust
+use mud_perspective::models::RenderContext;
+
+let ctx = RenderContext::new("char_1")
+    .with_entity("goblin1", &goblin1)
+    .with_entity("goblin2", &goblin2);
+
+let matches = ctx.resolve_target("the first goblin's sword");
+for target_match in &matches {
+    println!("Matched key: {}, Path: {:?}", target_match.key, target_match.path);
+    if let Some(deep_entity) = target_match.resolve_deep_entity() {
+        // Use the resolved nested entity
+    }
+}
+```
+
+The `TargetMatch` struct contains the matched key, the base entity, the requested sub-element path, a `path_uncertain` boolean, and a `resolve_deep_entity()` helper method to easily fetch the nested item.
+
+* **Pronouns:** Evaluates against `recent_entities` (e.g., "him" matches the last male entity).
+* **Ordinals:** Maps words like "second" or postfixes like "wolf 2" to stable ordinals.
+* **Nested Properties:** Parses possessives like "Aldran's sword" into entity + path.
+* **Ambiguity:** Returns multiple matches if an input is vague (e.g., "goblin" might match several).
+
+#### TargetMatch & Strict Resolution
+
+The `path_uncertain` field is flagged as `true` if `get_property` fails to find the requested sub-element. Developers can use `ctx.resolve_target_strict("...")` to instantly filter out these invalid paths, ensuring only fully resolvable targets are returned.
+
+#### Entity Aliases
+
+Implement the new `aliases()` method on the `TemplateEntity` trait to return a list of alternative names. This allows the engine to automatically strip articles and match seamlessly.
+
+```rust
+impl TemplateEntity for Character {
+    // ... other methods ...
+
+    fn aliases(&self) -> Option<&[&str]> {
+        Some(&["boss", "dark lord"])
+    }
+}
+```
+
 ## **Cargo Features**
 
 By default, `mud_perspective` includes built-in support for parsing and safely skipping common MUD protocol tags. This ensures that the typography engine does not accidentally capitalize hidden metadata (e.g., changing `<color red>` to `<color Red>`) and that the AST compiler does not misinterpret braces or brackets hidden inside these tags.

--- a/README.md
+++ b/README.md
@@ -4,14 +4,14 @@ mud\_perspective is a Rust library designed to handle perspective-aware text gen
 
 ## **Goals**
 
-The primary goal of this crate is to provide a reliable, thread-safe templating system for game servers. Its core objectives include:
+The primary goal of this crate is to provide a thread-safe templating system for game servers. Its core objectives include:
 
 * **Stance Shifting:** Automatically transitioning between "Actor Stance" (addressing the viewer in the first/second person) and "Director Stance" (addressing the viewer in the third person).
 
 * **Subject-Verb Agreement:** Conjugating verbs correctly based on the grammatical number and person of the subject.  
 * **Irregular Verb Handling:** Utilizing a static dictionary to safely conjugate common irregular and modal verbs without relying strictly on algorithmic suffixes.  
 * **Epistemological Masking:** Allowing the underlying game logic to obscure entity names (e.g., using disguises or recognition systems) based on the specific observer viewing the text.
-* **Memory Efficiency:** Using a highly concurrent AST cache backed by a TinyLFU eviction strategy and Cow (Clone-on-Write) strings to minimize heap allocations and lock contention during high-frequency combat loops.
+* **Memory Efficiency:** Using a concurrent AST cache backed by a TinyLFU eviction strategy and Cow (Clone-on-Write) strings to minimize heap allocations and lock contention during high-frequency combat loops.
 
 ## **API Usage**
 
@@ -87,7 +87,7 @@ fn get_property(&self, property_name: &str) -> Option<&dyn TemplateEntity> {
 ```
 
 ### **2. Rendering Templates**  
-The engine provides a `render_msg!` macro to make evaluating templates against a context ergonomic for game logic.
+The engine provides a `render_msg!` macro to evaluate templates against a context.
 
 ```rust  
 use mud_perspective::{render_msg, TemplateCache};
@@ -136,7 +136,7 @@ let ctx_third = RenderContext::new("char_1")
 
 ### **2.2 Custom Runtime Verbs**
 
-The engine also allows developers to expand its vocabulary at runtime by injecting custom irregular verbs or dialect-specific forms. This makes it easy to add new verbs dynamically without modifying the static core map.
+The engine allows developers to expand its vocabulary at runtime by injecting custom irregular verbs or dialect-specific forms. This allows developers to add new verbs dynamically without modifying the static core map.
 
 ```rust
 use mud_perspective::grammar::{add_irregular_verb, remove_irregular_verb, clear_irregular_verbs};
@@ -184,7 +184,7 @@ let output = PerspectiveEngine::render(&template, &past_ctx)?;
 
 ### **2.5 Preserving Narrative Memory Across Game Ticks**
 
-Developers can extract the anaphora memory state to preserve pronoun continuity across asynchronous server ticks or distinct game events. This lets ambiguity detection carry over seamlessly between separate evaluation loops, even when a fresh `RenderContext` is created later.
+Developers can extract the anaphora memory state to preserve pronoun continuity across asynchronous server ticks or distinct game events. This allows ambiguity detection to carry over between separate evaluation loops, even when a fresh `RenderContext` is created later.
 
 ```rust
 use mud_perspective::{engine::PerspectiveEngine, models::RenderContext};
@@ -205,7 +205,7 @@ let new_ctx = RenderContext::new("char_1")
 ```
 ### **2.6 Omniscient Lookahead & Disambiguation**
 
-By default, the engine evaluates templates left-to-right sequentially, which can cause narrative "pop-in" where entities are introduced as "a goblin" and later upgraded to "another goblin" as more are discovered. For static room descriptions or pre-computed narratives, developers can opt into an AST Pre-Pass by calling `.with_lookahead(true)` on the `RenderContext`. This performs a full scan ahead of time to perfectly resolve all collisions and ordinals.
+By default, the engine evaluates templates left-to-right sequentially, which can cause narrative "pop-in" where entities are introduced as "a goblin" and later upgraded to "another goblin" as more are discovered. For static room descriptions or pre-computed narratives, developers can opt into an AST Pre-Pass by calling `.with_lookahead(true)` on the `RenderContext`. This performs a full scan ahead of time to resolve all collisions and ordinals.
 
 ```rust
 use mud_perspective::{engine::PerspectiveEngine, models::RenderContext};
@@ -223,7 +223,7 @@ let output = PerspectiveEngine::render(&template, &ctx)?;
 
 ### **3. Handling Groups and Swarms**
 
-The library provides a built-in `GroupEntity` to easily represent dynamic groups of characters or objects. It automatically handles Oxford comma formatting, injects "you" if the viewer is in the group, and evaluates as plural so verbs and pronouns automatically conjugate correctly ("attack" instead of "attacks", "themselves", etc.).
+The library provides a built-in `GroupEntity` to represent dynamic groups of characters or objects. It automatically handles Oxford comma formatting, injects "you" if the viewer is in the group, and evaluates as plural so verbs and pronouns automatically conjugate correctly ("attack" instead of "attacks", "themselves", etc.).
 
 Furthermore, the engine implements grammatical rules for mixed-person groups. If a group evaluates in the First Person alongside other entities, it decomposes and orders the pronouns (e.g., `"You, the goblin, and I"`). It also distributes joint possessive suffixes across the list if a possessive pronoun is involved (e.g., `"your, the goblin's, and my gold"`), and collapses mixed-group objective pronouns into `"us"`.
 
@@ -242,13 +242,13 @@ let template = cache.get_or_compile("{source} [source:open] the door.")?;
 
 * **Entities:** {key} inserts the entity's display name. Use {Key} to force capitalization mid-sentence. Prepend a plus (`{+key}`) to force the engine to render the character's 3rd-person name (Director Stance) even if the viewer is that character.
 * **Nested Properties:** Use dot-notation (e.g., `{source.weapon}`) to dynamically traverse nested entities. The parent entity must implement `get_property`. Nested properties inherit all formatting rules for articles, pronouns, and possessive suffixes.
-* **Possessive Nouns:** Append `'s` to any entity tag (e.g., `{source's}` or `{the:source's}`) to dynamically generate the correct possessive noun suffix. If the entity is the viewer, it automatically renders as "your" or "my". Plural entities ending in "s" (like "wolves") will correctly render with just an apostrophe ("wolves'"). Group Entities distribute possessives across all members if mixed with a pronoun (e.g., "your and the goblin's"), or append to the final item (e.g., "Aldran and the goblin's").
+* **Possessive Nouns:** Append `'s` or just a trailing apostrophe (`'`) to any entity tag (e.g., `{source's}` or `{wolves'}`) to dynamically generate the correct possessive noun suffix. If the entity is the viewer, it automatically renders as "your" or "my". Plural entities ending in "s" (like "wolves") will correctly render with just an apostrophe ("wolves'"). Group Entities distribute possessives across all members if mixed with a pronoun (e.g., "your and the goblin's"), or append to the final item (e.g., "Aldran and the goblin's").
 * **Articles / Demonstratives:** You can use `a`, `the`, `this`, `that`, `another`, `one`, `one of the`, and `some` in front of any key to automatically append the article. Indefinite articles ("a") automatically adapt to "some" for plural entities, and demonstratives automatically adapt to plural ("these", "those"). Use `{A:key}`, `{The:key}`, etc. to force capitalization mid-sentence. These are automatically suppressed if the entity evaluates to the viewer ("you") or is flagged as a proper noun. You can force an article to render for a proper noun by prepending a plus sign (e.g., `{+this:key}`). You can disable the automatic upgrade of "a" to "the" for previously seen entities by prepending an exclamation mark (e.g., `{!a:key}`).
   * *Ordinals:* If multiple indistinguishable entities are introduced in the same context, the engine automatically upgrades "another" into ordinals ("a third", "a fourth"). You can reference them explicitly with definite articles (e.g. `{the:w1}` -> "the first wolf", `{the:w2}` -> "the second wolf"). Ordinals are stable, meaning they persist even if other entities leave the room, and reset automatically when the group drops to a single member. By default, ordinals are rendered as words up to 999, after which they switch to integer form ("1000th"). You can configure this threshold using `ctx.with_ordinal_word_threshold(20)`.
-* **Singular Overrides:** Prepend a minus sign (`{-source}`) to force a plural entity to be treated as singular for verbs and pronouns. This is extremely useful when combined with the `one of the` article to target a specific individual in a swarm (e.g., `{One of the:wolves} [-wolves:howl]` -> "One of the wolves howls.").
+* **Singular Overrides:** Prepend a minus sign (`{-source}`) to force a plural entity to be treated as singular for verbs and pronouns. This is useful when combined with the `one of the` article to target a specific individual in a swarm (e.g., `{One of the:wolves} [-wolves:howl]` -> "One of the wolves howls.").
 * **Pronouns:** {key:type}. Supported types include subj (he/she/it/they), obj (him/her/it/them), poss (his/her/their), abs_poss (his/hers/theirs), and reflex (himself/themselves). Capitalize the type (e.g., {key:Subj}) to force capitalization mid-sentence. Prepend a plus (`{+key:subj}`) to force a 3rd-person pronoun (e.g., he/she/it/they) even if the viewer is the entity. You can force a pronoun to render even if the engine detects it would be ambiguous by prepending an exclamation mark to the type (e.g., `{key:!subj}`). The engine features automatic Anaphora Resolution to prevent pronoun ambiguity (see Section 5).
 
-* **Verbs:** [key:verb] explicitly binds a base verb to a subject to ensure correct conjugation (including "be" -> "is"/"are" in the present tense, "was"/"were" in the past tense, and "will be" in the future tense). All verbs must be written in their base form (e.g. `[source:attack]`, not `[source:attacked]`) so the engine can accurately shift between tenses. Capitalize the verb (e.g., [key:Verb]) to force capitalization mid-sentence. Prepend a plus (`[+key:verb]`) to force 3rd-person conjugation. You can also bypass conjugation across all perspectives by appending a pipe and the desired form (e.g., `[key:be|be]`). You can provide multiple pipe segments to explicitly define the forms for different perspectives: `[key:freak out|freak out|freaks out]` (base/plural and 3rd-person singular) or `[key:be|am|are|is]` (1st-person singular, 2nd-person/plural, and 3rd-person singular). To provide overrides for the past tense, append a semicolon `;` followed by the past tense forms (e.g., `[key:be|am|are|is;was|were|was]`). You can provide *only* past tense overrides by omitting the present tense segment entirely (e.g., `[key:run|;ran]`). If a tense is omitted, the engine will safely fall back to native automatic conjugation for that tense. Future tense is strictly generated by naturally prepending "will" to the base verb, and safely ignores all inline overrides. Phrasal verbs (e.g. `[key:pick up]`) are naturally supported; the engine dynamically isolates the first word to ensure `"pick up"` correctly conjugates to `"picks up"`.
+* **Verbs:** [key:verb] explicitly binds a base verb to a subject to ensure correct conjugation (including "be" -> "is"/"are" in the present tense, "was"/"were" in the past tense, and "will be" in the future tense). All verbs must be written in their base form (e.g. `[source:attack]`, not `[source:attacked]`) so the engine can shift between tenses. Capitalize the verb (e.g., [key:Verb]) to force capitalization mid-sentence. Prepend a plus (`[+key:verb]`) to force 3rd-person conjugation. You can also bypass conjugation across all perspectives by appending a pipe and the desired form (e.g., `[key:be|be]`). You can provide multiple pipe segments to explicitly define the forms for different perspectives: `[key:freak out|freak out|freaks out]` (base/plural and 3rd-person singular) or `[key:be|am|are|is]` (1st-person singular, 2nd-person/plural, and 3rd-person singular). To provide overrides for the past tense, append a semicolon `;` followed by the past tense forms (e.g., `[key:be|am|are|is;was|were|was]`). You can provide *only* past tense overrides by omitting the present tense segment entirely (e.g., `[key:run|;ran]`). If a tense is omitted, the engine will fall back to native automatic conjugation for that tense. Future tense is generated by prepending "will" to the base verb, and ignores all inline overrides. Phrasal verbs (e.g. `[key:pick up]`) are naturally supported; the engine isolates the first word to ensure `"pick up"` conjugates to `"picks up"`.
 * **Colliding Verbs:** Some verbs share the same base form but have different past tense conjugations depending on their meaning (e.g., "to lie" -> *lay* vs *lied*). To guarantee the intended meaning when shifting to the past tense, annotate the base verb using parentheses: `[source:lie(lay)]` or `[source:lie(lied)]`. If you use an ambiguous base verb without annotation, the template compiler will emit a warning logging the available options, and default to the first dictionary entry.
 
 * **Escaping:** Use a backslash (`\`) to escape special characters if you need to output literal braces or brackets (e.g., `\{`, `\}`, `\[`, `\]`). You can also escape a backslash itself (`\\`).
@@ -268,27 +268,27 @@ For hypothetical "to be" scenarios, use inline overrides to force the static con
 
 ### **4.3 Future Tense and "Do-Support"**
 
-English uses the auxiliary verb "to do" to form negative sentences and questions (e.g., "Aldran *does* not run", "*Does* Aldran run?"). In the future tense, "do" is dropped and replaced with "will" ("Aldran *will* not run", "*Will* Aldran run?"). Because the engine evaluates tags independently and cannot determine if "do" is an auxiliary verb or a main verb (e.g., "Aldran *does* the laundry"), it natively treats all instances of "do" as main verbs. 
+English uses the auxiliary verb "to do" to form negative sentences and questions (e.g., "Aldran *does* not run", "*Does* Aldran run?"). In the future tense, "do" is dropped and replaced with "will" ("Aldran *will* not run", "*Will* Aldran run?"). Because the engine evaluates tags independently and cannot determine if "do" is an auxiliary verb or a main verb (e.g., "Aldran *does* the laundry"), it treats all instances of "do" as main verbs. 
 
 To fix this, annotate the verb as an auxiliary helper: `[source:do(aux)]`. 
 *   `{source} [source:do(aux)] not run.`
 *   **Present:** "Aldran does not run."
 *   **Past:** "Aldran did not run."
-*   **Future:** "Aldran will not run." (The engine safely drops "do" and substitutes "will").
+*   **Future:** "Aldran will not run." (The engine drops "do" and substitutes "will").
 
 ### **5. Smart Pronouns & Anaphora Resolution**
 
 The engine features an Anaphora Resolution system. It allows you to write templates almost entirely with pronouns (e.g., `{target:Subj} [target:look] at {target:reflex}.`), and dynamically decides when to introduce the full name ("The goblin looks at itself.") and when to use pronouns ("It looks at itself.").
 
 * **How it Triggers:** Whenever the engine encounters a pronoun tag, it checks the context's memory. If the entity hasn't been introduced yet, it will expand the pronoun into a fully formatted noun (including definite articles or possessive suffixes, like `the goblin's`).
-* **Ambiguity Detection:** In plain terms, the engine behaves like a reader. If a pronoun is requested for an entity that isn't the active subject, the engine evaluates the "cast" of recently mentioned characters. If any other recently mentioned character shares the exact same grammatical gender and plurality (e.g., two male characters in the same sentence), the engine recognizes that outputting "He" would confuse the reader. It falls back to the full name to guarantee clarity.
+* **Ambiguity Detection:** In plain terms, the engine behaves like a reader. If a pronoun is requested for an entity that isn't the active subject, the engine evaluates the "cast" of recently mentioned characters. If any other recently mentioned character shares the exact same grammatical gender and plurality (e.g., two male characters in the same sentence), the engine recognizes that outputting "He" would confuse the reader. It falls back to the full name to ensure clarity.
 * **Cross-Context Memory:** The anaphora memory lives inside the `RenderContext`. 
   * **Chaining:** You can render multiple templates in a row using the same context, and the engine will maintain narrative continuity across the templates.
   * **Game Ticks:** If your game loop spans across multiple server ticks or async events, you can extract the full narrative state using `let state = ctx.extract_anaphora()` and inject it into a brand new context later using `RenderContext::new(...).with_anaphora(state)`. This ensures ambiguity detection carries over.
 * **Memory Limits (LRU):** To prevent memory from growing unbounded during extremely long, continuous encounters, the anaphora memory acts as a Least-Recently-Used (LRU) cache defaulting to 15 entities. You can configure this limit using `ctx.with_anaphora_limit(size)`.
 * **Pinning & Manual Control:** In crowded scenarios, important characters might get pushed out of the LRU cache by a flurry of secondary actors. Protect them by pinning them into memory using `ctx.with_pinned_entity("key")` or `ctx.pin_anaphora("key")`. You can unpin them using `ctx.unpin_anaphora("key")`. You can also explicitly remove entities using `ctx.without_anaphora("key")` or `ctx.forget_anaphora("key")`.
 * **Forcing Behaviors:** If you explicitly want to suppress the engine's anaphoric article upgrades or pronoun ambiguity fallbacks, you can use the `!` prefix modifier. Writing `{!a:source}` prevents "a" from upgrading to "the". Writing `{source:!subj}` forces the engine to output the pronoun even if it detects an ambiguous collision in the current memory.
-* **Resetting Memory:** To manually clear the engine's memory, call `ctx.clear_anaphora()`. You should do this whenever narrative continuity is broken to prevent awkward, lingering pronoun references. Good times to call this include:
+* **Resetting Memory:** To manually clear the engine's memory, call `ctx.clear_anaphora()`. You should do this whenever narrative continuity is broken to prevent lingering pronoun references. Good times to call this include:
   * When a player moves to a new room or area.
   * When a significant amount of time passes between events.
   * At the start of a new, unrelated combat round or distinct paragraph.
@@ -315,7 +315,7 @@ let template = cache.get_or_compile(
 
 ### **6. Target Resolution**
 
-The `RenderContext` now provides a built-in `resolve_target` API to map natural language player commands (like "attack him", "steal Aldran's sword", or "look at the second wolf") back to game entities using the context's active anaphora and ordinal memory.
+The `RenderContext` provides a `resolve_target` API to map natural language player commands (like "attack him", "steal Aldran's sword", or "look at the second wolf") back to game entities using the context's active anaphora and ordinal memory.
 
 ```rust
 use mud_perspective::models::RenderContext;
@@ -333,20 +333,21 @@ for target_match in &matches {
 }
 ```
 
-The `TargetMatch` struct contains the matched key, the base entity, the requested sub-element path, a `path_uncertain` boolean, and a `resolve_deep_entity()` helper method to easily fetch the nested item.
+The `TargetMatch` struct contains the matched key, the base entity, the requested sub-element path, a `path_uncertain` boolean, and a `resolve_deep_entity()` helper method to fetch the nested item.
 
 * **Pronouns:** Evaluates against `recent_entities` (e.g., "him" matches the last male entity).
 * **Ordinals:** Maps words like "second" or postfixes like "wolf 2" to stable ordinals.
 * **Nested Properties:** Parses possessives like "Aldran's sword" into entity + path.
 * **Ambiguity:** Returns multiple matches if an input is vague (e.g., "goblin" might match several).
+* **Incomplete Possessives:** If a user submits an incomplete possessive (like "take Aldran's"), the engine intentionally returns `0` matches. This prevents the player from targeting the base entity (Aldran himself) and allows your game to respond with "Aldran's what?".
 
 #### TargetMatch & Strict Resolution
 
-The `path_uncertain` field is flagged as `true` if `get_property` fails to find the requested sub-element. Developers can use `ctx.resolve_target_strict("...")` to instantly filter out these invalid paths, ensuring only fully resolvable targets are returned.
+The `path_uncertain` field is flagged as `true` if `get_property` fails to find the requested sub-element. Developers can use `ctx.resolve_target_strict("...")` to filter out these invalid paths, ensuring only fully resolvable targets are returned.
 
 #### Entity Aliases
 
-Implement the new `aliases()` method on the `TemplateEntity` trait to return a list of alternative names. This allows the engine to automatically strip articles and match seamlessly.
+Implement the `aliases()` method on the `TemplateEntity` trait to return a list of alternative names. This allows the engine to strip articles and match alternative names.
 
 ```rust
 impl TemplateEntity for Character {
@@ -358,15 +359,24 @@ impl TemplateEntity for Character {
 }
 ```
 
+#### Strict Diacritics (Unicode Transliteration)
+
+By default, the target resolution engine transliterates accents and diacritics to their closest ASCII equivalents. This means a player can type "angry wolf" to target an entity named "Ängry Wölf". If a game world relies heavily on constructed languages or specific lore terminology where diacritics matter, builders can disable this fuzzy matching.
+
+```rust
+let ctx = RenderContext::new("char_1").with_strict_diacritics(true);
+// "angry wolf" will now fail to match "Ängry Wölf" because the player must type it exactly.
+```
+
 ## **Cargo Features**
 
-By default, `mud_perspective` includes built-in support for parsing and safely skipping common MUD protocol tags. This ensures that the typography engine does not accidentally capitalize hidden metadata (e.g., changing `<color red>` to `<color Red>`) and that the AST compiler does not misinterpret braces or brackets hidden inside these tags.
+By default, `mud_perspective` includes support for parsing and skipping common MUD protocol tags. This prevents the typography engine from capitalizing hidden metadata (e.g., changing `<color red>` to `<color Red>`) and the AST compiler from misinterpreting braces or brackets hidden inside these tags.
 
-* `ansi`: Safely skips ANSI escape sequences (e.g., `\x1b[31m`).
-* `mxp`: Safely skips MUD eXtension Protocol HTML-like tags (e.g., `<SEND HREF="look">`).
-* `msp`: Safely skips MUD Sound Protocol triggers (e.g., `!!SOUND(roar.wav)`).
+* `ansi`: skips ANSI escape sequences (e.g., `\x1b[31m`).
+* `mxp`: skips MUD eXtension Protocol HTML-like tags (e.g., `<SEND HREF="look">`).
+* `msp`: skips MUD Sound Protocol triggers (e.g., `!!SOUND(roar.wav)`).
 
-These are enabled by default. If your MUD does not use some or all of these protocols, you can disable them to eke out extra performance during the compilation and rendering phases:
+These are enabled by default. If your MUD does not use some or all of these protocols, you can disable them to reduce overhead during the compilation and rendering phases:
 
 ```toml
 [dependencies]

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -2,7 +2,7 @@ use crate::engine::Template;
 use moka::sync::Cache;
 use std::sync::Arc;
 
-/// A highly concurrent, thread-safe cache for compiled text templates.
+/// A concurrent, thread-safe cache for compiled text templates.
 ///
 /// Because MUDs process high volumes of text concurrently, this cache wraps the
 /// underlying owned ASTs in an `Arc`. This allows multiple network threads to safely

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -284,7 +284,7 @@ impl Template {
                 let (forced_present, forced_past) = parse_forced_conjugations(forced, content)?;
                 (base_verb.trim(), forced_present, forced_past)
             } else {
-                (verb_part.trim(), None, None)
+                (verb_part, None, None)
             };
 
         let original_verb = actual_verb.to_string();
@@ -1872,16 +1872,15 @@ fn effective_viewer_id<'a>(ctx: &RenderContext<'a>, force_3rd_person: bool) -> &
 /// Parses possessive suffix `'s`, returning the stripped string and a boolean flag.
 #[inline]
 fn parse_possessive_suffix(s: &str) -> (&str, bool) {
-    let s_trimmed = s.trim_end();
-    if let Some(stripped) = s_trimmed.strip_suffix(MOD_POSSESSIVE) {
-        (stripped.trim_end(), true)
-    } else if let Some(stripped) = s_trimmed.strip_suffix("’s") {
-        (stripped.trim_end(), true)
-    } else if let Some(stripped) = s_trimmed.strip_suffix('\'') {
-        (stripped.trim_end(), true)
-    } else if let Some(stripped) = s_trimmed.strip_suffix('’') {
-        (stripped.trim_end(), true)
+    if let Some(stripped) = s.strip_suffix(MOD_POSSESSIVE) {
+        (stripped, true)
+    } else if let Some(stripped) = s.strip_suffix("’s") {
+        (stripped, true)
+    } else if let Some(stripped) = s.strip_suffix('\'') {
+        (stripped, true)
+    } else if let Some(stripped) = s.strip_suffix('’') {
+        (stripped, true)
     } else {
-        (s_trimmed, false)
+        (s, false)
     }
 }

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -275,16 +275,16 @@ impl Template {
         let (actual_verb, forced_present, forced_past) =
             if let Some((base_verb, forced)) = verb_part.split_once(VERB_FORM_SEP) {
                 reject_if(
-                    base_verb.is_empty() || forced.is_empty(),
+                    base_verb.trim().is_empty() || forced.trim().is_empty(),
                     "Verb tag has an empty verb or forced conjugation segment",
                     content,
                     TAG_VERB_OPEN,
                 )?;
 
                 let (forced_present, forced_past) = parse_forced_conjugations(forced, content)?;
-                (base_verb, forced_present, forced_past)
+                (base_verb.trim(), forced_present, forced_past)
             } else {
-                (verb_part, None, None)
+                (verb_part.trim(), None, None)
             };
 
         let original_verb = actual_verb.to_string();
@@ -1011,7 +1011,7 @@ impl PerspectiveEngine {
         #[cfg(any(feature = "mxp", feature = "msp", feature = "ansi"))]
         {
             // Fast-path: If no protocol triggers exist, use Rust's native reverse iterator.
-            // (SIMD pre-scan is highly optimized, and next_back() evaluates from the end).
+            // (SIMD pre-scan is optimized, and next_back() evaluates from the end).
             if !has_protocol_tags(input) {
                 return input.trim_end().chars().next_back();
             }
@@ -1499,6 +1499,7 @@ fn parse_stance_prefixes(mut s: &str) -> (&str, bool, bool, bool) {
     let mut no_smart = false;
     let mut force_singular = false;
     loop {
+        s = s.trim_start();
         if let Some(stripped) = s.strip_prefix(MOD_FORCE_3RD_PERSON) {
             force_3rd_person = true;
             s = stripped;
@@ -1575,7 +1576,10 @@ fn parse_forced_conjugations(
         };
 
     if !pres_str.is_empty() {
-        let parts: Vec<String> = pres_str.split(VERB_FORM_SEP).map(str::to_string).collect();
+        let parts: Vec<String> = pres_str
+            .split(VERB_FORM_SEP)
+            .map(|s| s.trim().to_string())
+            .collect();
         for part in &parts {
             reject_if(
                 part.is_empty(),
@@ -1602,7 +1606,7 @@ fn parse_forced_conjugations(
         )?;
         let parts: Vec<String> = past_overrides_str
             .split(VERB_FORM_SEP)
-            .map(str::to_string)
+            .map(|s| s.trim().to_string())
             .collect();
         for part in &parts {
             reject_if(
@@ -1631,8 +1635,8 @@ fn split_tag<'a>(
     malformed_msg: &str,
 ) -> Result<(&'a str, Option<&'a str>), String> {
     let mut parts = content.split(TAG_SEPARATOR);
-    let p1 = parts.next().unwrap_or_default();
-    let p2 = parts.next();
+    let p1 = parts.next().unwrap_or_default().trim();
+    let p2 = parts.next().map(str::trim);
     reject_if(parts.next().is_some(), malformed_msg, content, open_char)?;
     Ok((p1, p2))
 }
@@ -1817,7 +1821,7 @@ fn reject_if(
     }
 }
 
-/// Performs a highly optimized SIMD pre-scan to detect the presence of protocol triggers.
+/// Performs a SIMD pre-scan to detect the presence of protocol triggers.
 ///
 /// **Optimization Rationale:** By running this once before iterating over a string's characters,
 /// the engine can completely bypass the overhead of slicing and tag validation inside the hot loop
@@ -1868,9 +1872,16 @@ fn effective_viewer_id<'a>(ctx: &RenderContext<'a>, force_3rd_person: bool) -> &
 /// Parses possessive suffix `'s`, returning the stripped string and a boolean flag.
 #[inline]
 fn parse_possessive_suffix(s: &str) -> (&str, bool) {
-    if let Some(stripped) = s.strip_suffix(MOD_POSSESSIVE) {
-        (stripped, true)
+    let s_trimmed = s.trim_end();
+    if let Some(stripped) = s_trimmed.strip_suffix(MOD_POSSESSIVE) {
+        (stripped.trim_end(), true)
+    } else if let Some(stripped) = s_trimmed.strip_suffix("’s") {
+        (stripped.trim_end(), true)
+    } else if let Some(stripped) = s_trimmed.strip_suffix('\'') {
+        (stripped.trim_end(), true)
+    } else if let Some(stripped) = s_trimmed.strip_suffix('’') {
+        (stripped.trim_end(), true)
     } else {
-        (s, false)
+        (s_trimmed, false)
     }
 }

--- a/src/grammar.rs
+++ b/src/grammar.rs
@@ -354,10 +354,10 @@ fn conjugate_regular_verb<'a>(original_verb: &'a str, lower_verb: &'a str) -> Co
     } else if lower_verb.ends_with("ch")
         || lower_verb.ends_with("sh")
         // WARNING: Do not "fix" the 'o' rule to account for preceding vowels (e.g. radios vs echoes).
-        // This algorithmic fallback MUST perfectly mirror the logic in `process.py` used to
-        // generate our static irregular verbs map. If we make this algorithm smarter, we will 
-        // break conjugation for verbs that the Python script correctly relegated to the irregular map
-        // (or break verbs it correctly assumed would be handled by this dumb rule)!
+        // This algorithmic fallback MUST strictly mirror the logic in `process.py` used to
+        // generate our static irregular verbs map. If we alter this algorithm, we will 
+        // break conjugation for verbs that the Python script relegated to the irregular map
+        // (or break verbs it assumed would be handled by this rule)!
         || lower_verb.ends_with(['s', 'x', 'z', 'o'])
     {
         Cow::Owned(format!("{original_verb}es"))
@@ -832,7 +832,7 @@ pub fn resolve_article(
     }
 }
 
-/// Formats a list of strings into a grammatically correct, Oxford comma-separated string.
+/// Formats a list of strings into an Oxford comma-separated string.
 #[must_use]
 pub fn format_oxford_list(mut items: Vec<Cow<'_, str>>) -> Cow<'_, str> {
     match items.len() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,7 +69,7 @@ macro_rules! render_msg {
 
 /// Ergonomically registers multiple custom irregular verbs into the runtime dictionary at once.
 ///
-/// This macro is highly useful during server initialization for injecting a large
+/// This macro is useful during server initialization for injecting a large
 /// number of custom or lore-specific verbs. It silently overwrites any existing
 /// runtime entries for the provided base verbs.
 ///

--- a/src/models.rs
+++ b/src/models.rs
@@ -3,7 +3,7 @@ use std::cell::RefCell;
 use std::collections::HashMap;
 use std::collections::HashSet;
 
-/// The highly unique sentinel string used by the engine to temporarily force the Director Stance.
+/// The unique sentinel string used by the engine to temporarily force the Director Stance.
 pub const NULL_VIEWER: &str = "\0__MUD_PERSPECTIVE_NULL_VIEWER__\0";
 
 /// Represents the grammatical gender of an entity for correct pronoun resolution.
@@ -54,7 +54,7 @@ pub enum Tense {
 /// like stealth, disguises, and recognition.
 ///
 /// **Note on Forced Perspectives:** When a template forces the Director Stance
-/// (e.g., `{+source}`), the engine temporarily passes a highly unique sentinel string
+/// (e.g., `{+source}`), the engine temporarily passes a unique sentinel string
 /// ([`NULL_VIEWER`]) as the `viewer_id` to bypass recognition.
 /// Ensure your actual entity IDs do not match this sentinel.
 pub trait TemplateEntity {
@@ -167,6 +167,9 @@ pub struct RenderContext<'a> {
     /// The number at which ordinal words ("third") switch to integer form ("3rd"). Defaults to 999.
     /// Set to 0 to always use integer form.
     pub ordinal_word_threshold: usize,
+    /// If true, disables the transliteration of Unicode characters (like `Ä`) to ASCII (`A`) during target resolution.
+    /// Defaults to false.
+    pub strict_diacritics: bool,
     /// The maximum number of entities to track for anaphora resolution before evicting the oldest.
     /// Defaults to 15. Set to 0 for unbounded growth.
     /// If all entities in memory are pinned, this limit will be temporarily exceeded to preserve narrative continuity.
@@ -260,19 +263,25 @@ impl<'a> TargetMatch<'a> {
     #[must_use]
     pub fn resolve_deep_entity(&self) -> Option<&'a dyn TemplateEntity> {
         if let Some(ref path) = self.path {
-            let mut current = self.entity;
-            for prop in path.split('.') {
-                if let Some(next) = current.get_property(prop) {
-                    current = next;
-                } else {
-                    return None;
-                }
-            }
-            Some(current)
+            resolve_entity_path(self.entity, path)
         } else {
             Some(self.entity)
         }
     }
+}
+
+fn resolve_entity_path<'a>(
+    mut current: &'a dyn TemplateEntity,
+    path: &str,
+) -> Option<&'a dyn TemplateEntity> {
+    for prop in path.split('.') {
+        if let Some(next) = current.get_property(prop) {
+            current = next;
+        } else {
+            return None;
+        }
+    }
+    Some(current)
 }
 
 impl<'a> RenderContext<'a> {
@@ -288,6 +297,7 @@ impl<'a> RenderContext<'a> {
             tense: Tense::Present,
             lookahead: false,
             ordinal_word_threshold: 999,
+            strict_diacritics: false,
             anaphora_limit: 15,
             entities: HashMap::new(),
             last_mentioned: RefCell::new(None),
@@ -320,17 +330,7 @@ impl<'a> RenderContext<'a> {
         for (key, entity) in matches {
             if seen.insert(key.clone()) {
                 let path_uncertain = if let Some(ref path) = sub_element_desc {
-                    let mut current_entity = entity;
-                    let mut exists = true;
-                    for prop in path.split('.') {
-                        if let Some(next) = current_entity.get_property(prop) {
-                            current_entity = next;
-                        } else {
-                            exists = false;
-                            break;
-                        }
-                    }
-                    !exists
+                    resolve_entity_path(entity, path).is_none()
                 } else {
                     false
                 };
@@ -478,51 +478,38 @@ impl<'a> RenderContext<'a> {
         entity: &dyn TemplateEntity,
         clean_desc: &str,
     ) -> bool {
-        let short_name = entity.display_name_for(self.viewer_id).to_lowercase();
-        let short_name_3rd = entity.display_name_for(NULL_VIEWER).to_lowercase();
-        let long_name = entity
-            .long_display_name_for(self.viewer_id)
-            .map(|n| n.to_lowercase());
+        let short_name = entity.display_name_for(self.viewer_id);
+        let short_name_3rd = entity.display_name_for(NULL_VIEWER);
+        let long_name = entity.long_display_name_for(self.viewer_id);
 
-        let clean_short = strip_articles(&short_name);
-        let clean_short_3rd = strip_articles(&short_name_3rd);
-
-        if clean_desc == clean_short || clean_desc == clean_short_3rd {
-            return true;
-        }
+        let mut names_to_check = vec![short_name.as_ref(), short_name_3rd.as_ref()];
         if let Some(ref ln) = long_name {
-            let clean_long = strip_articles(ln);
-            if clean_desc == clean_long {
+            names_to_check.push(ln.as_ref());
+        }
+
+        for name in &names_to_check {
+            if eq_ignore_case(clean_desc, strip_articles(name), self.strict_diacritics) {
                 return true;
             }
         }
 
         if let Some(aliases) = entity.aliases() {
             for alias in aliases {
-                let lower_alias = alias.to_lowercase();
-                let clean_alias = strip_articles(&lower_alias);
-                if clean_desc == clean_alias {
+                if eq_ignore_case(clean_desc, strip_articles(alias), self.strict_diacritics) {
                     return true;
                 }
             }
         }
 
-        if self.check_ordinals(&short_name, key, clean_desc, entity) {
-            return true;
-        }
-        if self.check_ordinals(&short_name_3rd, key, clean_desc, entity) {
-            return true;
-        }
-        if let Some(ref ln) = long_name
-            && self.check_ordinals(ln, key, clean_desc, entity)
-        {
-            return true;
+        for name in &names_to_check {
+            if self.check_ordinals(name, key, clean_desc, entity) {
+                return true;
+            }
         }
 
         false
     }
 
-    #[allow(clippy::similar_names)]
     fn check_ordinals(
         &self,
         name_to_check: &str,
@@ -541,91 +528,89 @@ impl<'a> RenderContext<'a> {
 
         let ord_word =
             crate::grammar::number_to_ordinal_word(ord, self.ordinal_word_threshold).to_lowercase();
-        let ord_num_th = format!("{ord}th");
-        let ord_num_1st = format!("{ord}st");
-        let ord_num_2nd = format!("{ord}nd");
-        let ord_num_3rd = format!("{ord}rd");
-        let ord_num_plain = format!("{ord}");
+        let ord_str = ord.to_string();
 
-        let matches_prefix = clean_desc.starts_with(&ord_word)
-            || clean_desc.starts_with(&ord_num_th)
-            || clean_desc.starts_with(&ord_num_1st)
-            || clean_desc.starts_with(&ord_num_2nd)
-            || clean_desc.starts_with(&ord_num_3rd)
-            || clean_desc.starts_with(&ord_num_plain);
+        let clean_name = strip_articles(name_to_check);
 
-        if matches_prefix {
-            let clean_name = strip_articles(name_to_check);
-
-            let ord_prefix_len = if clean_desc.starts_with(&ord_word) {
-                ord_word.len()
-            } else if clean_desc.starts_with(&ord_num_th) {
-                ord_num_th.len()
-            } else if clean_desc.starts_with(&ord_num_1st) {
-                ord_num_1st.len()
-            } else if clean_desc.starts_with(&ord_num_2nd) {
-                ord_num_2nd.len()
-            } else if clean_desc.starts_with(&ord_num_3rd) {
-                ord_num_3rd.len()
-            } else {
-                ord_num_plain.len()
-            };
-
-            let remainder = clean_desc[ord_prefix_len..].trim_start();
-
-            if remainder == clean_name {
+        let is_match = |remainder: &str| -> bool {
+            if eq_ignore_case(remainder, clean_name, self.strict_diacritics) {
                 return true;
             }
-            if let Some(collective) = entity.collective_noun() {
-                let coll_lower = collective.to_lowercase();
-                if remainder.starts_with(&coll_lower) && remainder.ends_with(clean_name) {
-                    return true;
-                }
+            if let Some(collective) = entity.collective_noun()
+                && starts_with_ignore_case(remainder, collective, self.strict_diacritics)
+                && ends_with_ignore_case(remainder, clean_name, self.strict_diacritics)
+            {
+                return true;
+            }
+            false
+        };
+
+        let check_prefix = |variant_len: usize| -> bool {
+            if clean_desc.len() > variant_len
+                && clean_desc.as_bytes().get(variant_len) == Some(&b' ')
+            {
+                let remainder = clean_desc[variant_len + 1..].trim_start();
+                is_match(remainder)
+            } else {
+                false
+            }
+        };
+
+        // 1. Prefix: Ordinal Word
+        if clean_desc.starts_with(&ord_word) && check_prefix(ord_word.len()) {
+            return true;
+        }
+
+        // 2. Prefix: Numeric Ordinal
+        if clean_desc.starts_with(&ord_str) {
+            let after_num = &clean_desc[ord_str.len()..];
+            let has_suffix = after_num.starts_with("th")
+                || after_num.starts_with("st")
+                || after_num.starts_with("nd")
+                || after_num.starts_with("rd");
+
+            if has_suffix && check_prefix(ord_str.len() + 2) {
+                return true;
+            }
+            if check_prefix(ord_str.len()) {
+                return true;
             }
         }
 
-        let postfix_word = format!(" {ord_word}");
-        let postfix_th = format!(" {ord_num_th}");
-        let postfix_1st = format!(" {ord_num_1st}");
-        let postfix_2nd = format!(" {ord_num_2nd}");
-        let postfix_3rd = format!(" {ord_num_3rd}");
-        let postfix_plain = format!(" {ord_num_plain}");
-
-        let matches_postfix = clean_desc.ends_with(&postfix_word)
-            || clean_desc.ends_with(&postfix_th)
-            || clean_desc.ends_with(&postfix_1st)
-            || clean_desc.ends_with(&postfix_2nd)
-            || clean_desc.ends_with(&postfix_3rd)
-            || clean_desc.ends_with(&postfix_plain);
-
-        if matches_postfix {
-            let clean_name = strip_articles(name_to_check);
-
-            let ord_postfix_len = if clean_desc.ends_with(&postfix_word) {
-                postfix_word.len()
-            } else if clean_desc.ends_with(&postfix_th) {
-                postfix_th.len()
-            } else if clean_desc.ends_with(&postfix_1st) {
-                postfix_1st.len()
-            } else if clean_desc.ends_with(&postfix_2nd) {
-                postfix_2nd.len()
-            } else if clean_desc.ends_with(&postfix_3rd) {
-                postfix_3rd.len()
+        let check_postfix = |variant_len: usize| -> bool {
+            if clean_desc.len() > variant_len
+                && clean_desc
+                    .as_bytes()
+                    .get(clean_desc.len() - variant_len - 1)
+                    == Some(&b' ')
+            {
+                let remainder = clean_desc[..clean_desc.len() - variant_len - 1].trim_end();
+                is_match(remainder)
             } else {
-                postfix_plain.len()
-            };
+                false
+            }
+        };
 
-            let remainder = clean_desc[..clean_desc.len() - ord_postfix_len].trim_end();
+        // 3. Postfix: Ordinal Word
+        if clean_desc.ends_with(&ord_word) && check_postfix(ord_word.len()) {
+            return true;
+        }
 
-            if remainder == clean_name {
+        // 4. Postfix: Numeric Ordinal
+        let has_suffix = clean_desc.ends_with("th")
+            || clean_desc.ends_with("st")
+            || clean_desc.ends_with("nd")
+            || clean_desc.ends_with("rd");
+
+        if has_suffix && clean_desc.len() >= 2 + ord_str.len() {
+            let num_end_idx = clean_desc.len() - 2;
+            if clean_desc[..num_end_idx].ends_with(&ord_str) && check_postfix(ord_str.len() + 2) {
                 return true;
             }
-            if let Some(collective) = entity.collective_noun() {
-                let coll_lower = collective.to_lowercase();
-                if remainder.starts_with(&coll_lower) && remainder.ends_with(clean_name) {
-                    return true;
-                }
-            }
+        }
+
+        if clean_desc.ends_with(&ord_str) && check_postfix(ord_str.len()) {
+            return true;
         }
 
         false
@@ -666,6 +651,15 @@ impl<'a> RenderContext<'a> {
     #[must_use]
     pub fn with_ordinal_word_threshold(mut self, threshold: usize) -> Self {
         self.ordinal_word_threshold = threshold;
+        self
+    }
+
+    /// Enables or disables strict diacritic matching for target resolution.
+    /// If `true`, users must input exact accents/diacritics to match entities.
+    /// If `false` (default), the engine transliterates Unicode to ASCII for fuzzy matching (e.g., "Ängry" matches "angry").
+    #[must_use]
+    pub fn with_strict_diacritics(mut self, strict: bool) -> Self {
+        self.strict_diacritics = strict;
         self
     }
 
@@ -915,7 +909,11 @@ fn strip_articles(mut s: &str) -> &str {
     while modified {
         modified = false;
         for prefix in &prefixes {
-            if s.starts_with(prefix) {
+            if s.len() >= prefix.len()
+                && s.as_bytes()
+                    .get(..prefix.len())
+                    .is_some_and(|b| b.eq_ignore_ascii_case(prefix.as_bytes()))
+            {
                 s = &s[prefix.len()..];
                 modified = true;
                 break;
@@ -925,51 +923,120 @@ fn strip_articles(mut s: &str) -> &str {
     s
 }
 
+#[inline]
+fn eq_ignore_case(lower_str: &str, mixed_str: &str, strict: bool) -> bool {
+    if lower_str.is_ascii() && mixed_str.is_ascii() {
+        lower_str.eq_ignore_ascii_case(mixed_str)
+    } else if strict {
+        lower_str
+            .chars()
+            .eq(mixed_str.chars().flat_map(char::to_lowercase))
+    } else {
+        deunicode::deunicode(lower_str).to_lowercase()
+            == deunicode::deunicode(mixed_str).to_lowercase()
+    }
+}
+
+#[inline]
+fn starts_with_ignore_case(lower_str: &str, mixed_prefix: &str, strict: bool) -> bool {
+    if lower_str.is_ascii() && mixed_prefix.is_ascii() {
+        lower_str.len() >= mixed_prefix.len()
+            && lower_str
+                .as_bytes()
+                .get(..mixed_prefix.len())
+                .is_some_and(|b| b.eq_ignore_ascii_case(mixed_prefix.as_bytes()))
+    } else if strict {
+        let mut s_iter = lower_str.chars();
+        for p in mixed_prefix.chars().flat_map(char::to_lowercase) {
+            if Some(p) != s_iter.next() {
+                return false;
+            }
+        }
+        true
+    } else {
+        deunicode::deunicode(lower_str)
+            .to_lowercase()
+            .starts_with(&deunicode::deunicode(mixed_prefix).to_lowercase())
+    }
+}
+
+#[inline]
+fn ends_with_ignore_case(lower_str: &str, mixed_suffix: &str, strict: bool) -> bool {
+    if lower_str.is_ascii() && mixed_suffix.is_ascii() {
+        lower_str.len() >= mixed_suffix.len()
+            && lower_str
+                .as_bytes()
+                .get(lower_str.len() - mixed_suffix.len()..)
+                .is_some_and(|b| b.eq_ignore_ascii_case(mixed_suffix.as_bytes()))
+    } else if strict {
+        let mut s_iter = lower_str.chars().rev();
+        for p in mixed_suffix
+            .chars()
+            .rev()
+            .flat_map(|c| c.to_lowercase().rev())
+        {
+            if Some(p) != s_iter.next() {
+                return false;
+            }
+        }
+        true
+    } else {
+        deunicode::deunicode(lower_str)
+            .to_lowercase()
+            .ends_with(&deunicode::deunicode(mixed_suffix).to_lowercase())
+    }
+}
+
 fn parse_target_description(desc: &str) -> (String, Option<String>) {
-    let lower = desc.to_lowercase();
+    let lower = desc.to_lowercase().replace('’', "'");
     let mut text = lower
         .trim()
-        .trim_end_matches(|c: char| c.is_ascii_punctuation());
+        .trim_end_matches(['.', '!', '?', ',', ';', ':']);
 
     let mut base = String::new();
-    let mut path_segments = Vec::new();
+    let mut path = String::new();
 
     let possessive_pronouns = ["his ", "her ", "its ", "their ", "your ", "my ", "our "];
     for prefix in &possessive_pronouns {
         if text.starts_with(prefix) {
-            base = prefix.trim().to_string();
+            base.push_str(prefix.trim());
             text = text[prefix.len()..].trim();
             break;
         }
     }
 
     while !text.is_empty() {
-        let (owner, advance) = if let Some(idx) = text.find("'s ") {
-            (text[..idx].to_string(), idx + 3)
+        let (owner, advance, add_s) = if let Some(idx) = text.find("'s ") {
+            (&text[..idx], idx + 3, false)
         } else if let Some(idx) = text.find("s' ") {
-            (format!("{}s", &text[..idx]), idx + 3)
+            (&text[..idx], idx + 3, true)
         } else if let Some(idx) = text.find("' ") {
-            (text[..idx].to_string(), idx + 2)
+            (&text[..idx], idx + 2, false)
         } else {
-            (text.to_string(), text.len())
+            (text, text.len(), false)
         };
 
         if base.is_empty() {
-            base = owner;
+            base.push_str(owner);
+            if add_s {
+                base.push('s');
+            }
         } else {
-            path_segments.push(owner);
+            if !path.is_empty() {
+                path.push('.');
+            }
+            path.push_str(owner);
+            if add_s {
+                path.push('s');
+            }
         }
 
         text = text.get(advance..).unwrap_or_default().trim();
     }
 
-    let path = if path_segments.is_empty() {
-        None
-    } else {
-        Some(path_segments.join("."))
-    };
+    let path_opt = if path.is_empty() { None } else { Some(path) };
 
-    (base, path)
+    (base, path_opt)
 }
 
 /// A type alias representing an evaluated group member and its resolved display name.

--- a/src/models.rs
+++ b/src/models.rs
@@ -1,6 +1,7 @@
 use std::borrow::Cow;
 use std::cell::RefCell;
 use std::collections::HashMap;
+use std::collections::HashSet;
 
 /// The highly unique sentinel string used by the engine to temporarily force the Director Stance.
 pub const NULL_VIEWER: &str = "\0__MUD_PERSPECTIVE_NULL_VIEWER__\0";
@@ -135,6 +136,12 @@ pub trait TemplateEntity {
     fn get_property(&self, _property_name: &str) -> Option<&dyn TemplateEntity> {
         None
     }
+
+    /// Returns an optional list of alternative names or aliases the user can use to target this entity.
+    /// Used exclusively by `RenderContext::resolve_target`.
+    fn aliases(&self) -> Option<&[&str]> {
+        None
+    }
 }
 
 /// Tracks the assignment of ordinals for entities with colliding names.
@@ -223,6 +230,51 @@ pub struct AnaphoraState {
     pub ordinals: HashMap<String, OrdinalState>,
 }
 
+/// Represents a matched entity and an optional sub-element path requested by the user.
+#[derive(Clone)]
+pub struct TargetMatch<'a> {
+    /// The template key of the matched entity.
+    pub key: String,
+    /// A reference to the matched entity.
+    pub entity: &'a dyn TemplateEntity,
+    /// An optional path to a sub-element (e.g., "sword" in "Aldran's sword").
+    pub path: Option<String>,
+    /// True if a `path` is present but the entity's `get_property` could not confirm it exists.
+    pub path_uncertain: bool,
+}
+
+impl std::fmt::Debug for TargetMatch<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("TargetMatch")
+            .field("key", &self.key)
+            .field("path", &self.path)
+            .field("path_uncertain", &self.path_uncertain)
+            .finish_non_exhaustive()
+    }
+}
+
+impl<'a> TargetMatch<'a> {
+    /// Resolves and returns the deepest sub-element `TemplateEntity` requested by the path.
+    /// If no path was requested, this returns the base matched entity.
+    /// If the requested path is invalid, returns `None`.
+    #[must_use]
+    pub fn resolve_deep_entity(&self) -> Option<&'a dyn TemplateEntity> {
+        if let Some(ref path) = self.path {
+            let mut current = self.entity;
+            for prop in path.split('.') {
+                if let Some(next) = current.get_property(prop) {
+                    current = next;
+                } else {
+                    return None;
+                }
+            }
+            Some(current)
+        } else {
+            Some(self.entity)
+        }
+    }
+}
+
 impl<'a> RenderContext<'a> {
     /// Initializes a new, empty rendering context for the specified viewer.
     ///
@@ -243,6 +295,340 @@ impl<'a> RenderContext<'a> {
             recent_entities: RefCell::new(Vec::new()),
             ordinals: RefCell::new(HashMap::new()),
         }
+    }
+
+    /// Resolves a natural language description (e.g., "him", "the fourth wolf", "Aldran's sword")
+    /// to the corresponding entities in the current context.
+    ///
+    /// Returns a list of `TargetMatch` objects. If the description is ambiguous (e.g., "him" when
+    /// two males are present), the list will contain multiple matches, allowing the caller to ask
+    /// the user for clarification.
+    ///
+    /// If the description references a sub-element (e.g., "his sword"), the `path` field will be
+    /// populated with "sword". If the parent entity does not expose this property via `get_property`,
+    /// `path_uncertain` will be `true`, allowing the caller to decide whether to accept it.
+    #[must_use]
+    pub fn resolve_target(&self, description: &str) -> Vec<TargetMatch<'a>> {
+        let (base_desc, sub_element_desc) = parse_target_description(description);
+
+        let matches = self
+            .resolve_pronoun_targets(&base_desc)
+            .unwrap_or_else(|| self.resolve_name_targets(&base_desc));
+
+        let mut unique_matches = Vec::new();
+        let mut seen = HashSet::new();
+        for (key, entity) in matches {
+            if seen.insert(key.clone()) {
+                let path_uncertain = if let Some(ref path) = sub_element_desc {
+                    let mut current_entity = entity;
+                    let mut exists = true;
+                    for prop in path.split('.') {
+                        if let Some(next) = current_entity.get_property(prop) {
+                            current_entity = next;
+                        } else {
+                            exists = false;
+                            break;
+                        }
+                    }
+                    !exists
+                } else {
+                    false
+                };
+
+                unique_matches.push(TargetMatch {
+                    key,
+                    entity,
+                    path: sub_element_desc.clone(),
+                    path_uncertain,
+                });
+            }
+        }
+
+        unique_matches
+    }
+
+    /// Resolves a natural language description to the corresponding entities in the current context,
+    /// strictly filtering out any matches where the requested sub-element path cannot be confirmed.
+    ///
+    /// This is equivalent to calling `resolve_target` and retaining only the matches where `path_uncertain` is `false`.
+    #[must_use]
+    pub fn resolve_target_strict(&self, description: &str) -> Vec<TargetMatch<'a>> {
+        self.resolve_target(description)
+            .into_iter()
+            .filter(|m| !m.path_uncertain)
+            .collect()
+    }
+
+    fn resolve_pronoun_targets(
+        &self,
+        base_desc: &str,
+    ) -> Option<Vec<(String, &'a dyn TemplateEntity)>> {
+        let is_pronoun = matches!(
+            base_desc,
+            "he" | "him"
+                | "his"
+                | "himself"
+                | "she"
+                | "her"
+                | "hers"
+                | "herself"
+                | "it"
+                | "its"
+                | "itself"
+                | "they"
+                | "them"
+                | "their"
+                | "theirs"
+                | "themselves"
+                | "you"
+                | "your"
+                | "yours"
+                | "yourself"
+                | "yourselves"
+                | "i"
+                | "me"
+                | "my"
+                | "mine"
+                | "myself"
+                | "we"
+                | "us"
+                | "our"
+                | "ours"
+                | "ourselves"
+        );
+
+        if !is_pronoun {
+            return None;
+        }
+
+        let mut matches = Vec::new();
+        for recent in self.recent_entities.borrow().iter() {
+            if let Some(&entity) = self.entities.get(recent.key.as_str()) {
+                let is_plural = recent.flags.contains(RecentEntityFlags::IS_PLURAL);
+                let gender = recent.gender;
+                let is_viewer = recent.flags.contains(RecentEntityFlags::IS_VIEWER_NORMAL)
+                    || recent.flags.contains(RecentEntityFlags::IS_VIEWER_FORCED);
+
+                let matches_pro = if is_viewer {
+                    matches!(
+                        base_desc,
+                        "you"
+                            | "your"
+                            | "yours"
+                            | "yourself"
+                            | "yourselves"
+                            | "i"
+                            | "me"
+                            | "my"
+                            | "mine"
+                            | "myself"
+                            | "we"
+                            | "us"
+                            | "our"
+                            | "ours"
+                            | "ourselves"
+                    )
+                } else {
+                    match base_desc {
+                        "he" | "him" | "his" | "himself" => gender == Gender::Male && !is_plural,
+                        "she" | "her" | "hers" | "herself" => {
+                            gender == Gender::Female && !is_plural
+                        }
+                        "it" | "its" | "itself" => gender == Gender::Neutral && !is_plural,
+                        "they" | "them" | "their" | "theirs" | "themselves" => {
+                            gender == Gender::Plural || is_plural
+                        }
+                        _ => false,
+                    }
+                };
+
+                if matches_pro {
+                    matches.push((recent.key.clone(), entity));
+                }
+            }
+        }
+
+        Some(matches)
+    }
+
+    fn resolve_name_targets(&self, base_desc: &str) -> Vec<(String, &'a dyn TemplateEntity)> {
+        let clean_desc = strip_articles(base_desc);
+        let mut name_matches = Vec::new();
+        for recent in self.recent_entities.borrow().iter() {
+            if let Some(&entity) = self.entities.get(recent.key.as_str())
+                && self.entity_matches_name(&recent.key, entity, clean_desc)
+            {
+                name_matches.push((recent.key.clone(), entity));
+            }
+        }
+
+        if name_matches.is_empty() {
+            for (&key, &entity) in &self.entities {
+                if self.entity_matches_name(key, entity, clean_desc) {
+                    name_matches.push((key.to_string(), entity));
+                }
+            }
+        }
+        name_matches
+    }
+
+    fn entity_matches_name(
+        &self,
+        key: &str,
+        entity: &dyn TemplateEntity,
+        clean_desc: &str,
+    ) -> bool {
+        let short_name = entity.display_name_for(self.viewer_id).to_lowercase();
+        let short_name_3rd = entity.display_name_for(NULL_VIEWER).to_lowercase();
+        let long_name = entity
+            .long_display_name_for(self.viewer_id)
+            .map(|n| n.to_lowercase());
+
+        let clean_short = strip_articles(&short_name);
+        let clean_short_3rd = strip_articles(&short_name_3rd);
+
+        if clean_desc == clean_short || clean_desc == clean_short_3rd {
+            return true;
+        }
+        if let Some(ref ln) = long_name {
+            let clean_long = strip_articles(ln);
+            if clean_desc == clean_long {
+                return true;
+            }
+        }
+
+        if let Some(aliases) = entity.aliases() {
+            for alias in aliases {
+                let lower_alias = alias.to_lowercase();
+                let clean_alias = strip_articles(&lower_alias);
+                if clean_desc == clean_alias {
+                    return true;
+                }
+            }
+        }
+
+        if self.check_ordinals(&short_name, key, clean_desc, entity) {
+            return true;
+        }
+        if self.check_ordinals(&short_name_3rd, key, clean_desc, entity) {
+            return true;
+        }
+        if let Some(ref ln) = long_name
+            && self.check_ordinals(ln, key, clean_desc, entity)
+        {
+            return true;
+        }
+
+        false
+    }
+
+    #[allow(clippy::similar_names)]
+    fn check_ordinals(
+        &self,
+        name_to_check: &str,
+        key: &str,
+        clean_desc: &str,
+        entity: &dyn TemplateEntity,
+    ) -> bool {
+        let ord = if let Some(ord_state) = self.ordinals.borrow().get(name_to_check) {
+            ord_state.members.get(key).copied()
+        } else {
+            None
+        };
+
+        // If the entity has no ordinal assigned (e.g. it's the only one present), assume it is the first.
+        let ord = ord.unwrap_or(1);
+
+        let ord_word =
+            crate::grammar::number_to_ordinal_word(ord, self.ordinal_word_threshold).to_lowercase();
+        let ord_num_th = format!("{ord}th");
+        let ord_num_1st = format!("{ord}st");
+        let ord_num_2nd = format!("{ord}nd");
+        let ord_num_3rd = format!("{ord}rd");
+        let ord_num_plain = format!("{ord}");
+
+        let matches_prefix = clean_desc.starts_with(&ord_word)
+            || clean_desc.starts_with(&ord_num_th)
+            || clean_desc.starts_with(&ord_num_1st)
+            || clean_desc.starts_with(&ord_num_2nd)
+            || clean_desc.starts_with(&ord_num_3rd)
+            || clean_desc.starts_with(&ord_num_plain);
+
+        if matches_prefix {
+            let clean_name = strip_articles(name_to_check);
+
+            let ord_prefix_len = if clean_desc.starts_with(&ord_word) {
+                ord_word.len()
+            } else if clean_desc.starts_with(&ord_num_th) {
+                ord_num_th.len()
+            } else if clean_desc.starts_with(&ord_num_1st) {
+                ord_num_1st.len()
+            } else if clean_desc.starts_with(&ord_num_2nd) {
+                ord_num_2nd.len()
+            } else if clean_desc.starts_with(&ord_num_3rd) {
+                ord_num_3rd.len()
+            } else {
+                ord_num_plain.len()
+            };
+
+            let remainder = clean_desc[ord_prefix_len..].trim_start();
+
+            if remainder == clean_name {
+                return true;
+            }
+            if let Some(collective) = entity.collective_noun() {
+                let coll_lower = collective.to_lowercase();
+                if remainder.starts_with(&coll_lower) && remainder.ends_with(clean_name) {
+                    return true;
+                }
+            }
+        }
+
+        let postfix_word = format!(" {ord_word}");
+        let postfix_th = format!(" {ord_num_th}");
+        let postfix_1st = format!(" {ord_num_1st}");
+        let postfix_2nd = format!(" {ord_num_2nd}");
+        let postfix_3rd = format!(" {ord_num_3rd}");
+        let postfix_plain = format!(" {ord_num_plain}");
+
+        let matches_postfix = clean_desc.ends_with(&postfix_word)
+            || clean_desc.ends_with(&postfix_th)
+            || clean_desc.ends_with(&postfix_1st)
+            || clean_desc.ends_with(&postfix_2nd)
+            || clean_desc.ends_with(&postfix_3rd)
+            || clean_desc.ends_with(&postfix_plain);
+
+        if matches_postfix {
+            let clean_name = strip_articles(name_to_check);
+
+            let ord_postfix_len = if clean_desc.ends_with(&postfix_word) {
+                postfix_word.len()
+            } else if clean_desc.ends_with(&postfix_th) {
+                postfix_th.len()
+            } else if clean_desc.ends_with(&postfix_1st) {
+                postfix_1st.len()
+            } else if clean_desc.ends_with(&postfix_2nd) {
+                postfix_2nd.len()
+            } else if clean_desc.ends_with(&postfix_3rd) {
+                postfix_3rd.len()
+            } else {
+                postfix_plain.len()
+            };
+
+            let remainder = clean_desc[..clean_desc.len() - ord_postfix_len].trim_end();
+
+            if remainder == clean_name {
+                return true;
+            }
+            if let Some(collective) = entity.collective_noun() {
+                let coll_lower = collective.to_lowercase();
+                if remainder.starts_with(&coll_lower) && remainder.ends_with(clean_name) {
+                    return true;
+                }
+            }
+        }
+
+        false
     }
 
     /// Configures the viewer ID for the rendering context.
@@ -510,6 +896,82 @@ pub(crate) fn flatten_group<'c>(
     }
 }
 
+fn strip_articles(mut s: &str) -> &str {
+    let prefixes = [
+        "the ",
+        "a ",
+        "an ",
+        "some ",
+        "this ",
+        "that ",
+        "another ",
+        "other ",
+        "these ",
+        "those ",
+        "one of the ",
+        "one of ",
+    ];
+    let mut modified = true;
+    while modified {
+        modified = false;
+        for prefix in &prefixes {
+            if s.starts_with(prefix) {
+                s = &s[prefix.len()..];
+                modified = true;
+                break;
+            }
+        }
+    }
+    s
+}
+
+fn parse_target_description(desc: &str) -> (String, Option<String>) {
+    let lower = desc.to_lowercase();
+    let mut text = lower
+        .trim()
+        .trim_end_matches(|c: char| c.is_ascii_punctuation());
+
+    let mut base = String::new();
+    let mut path_segments = Vec::new();
+
+    let possessive_pronouns = ["his ", "her ", "its ", "their ", "your ", "my ", "our "];
+    for prefix in &possessive_pronouns {
+        if text.starts_with(prefix) {
+            base = prefix.trim().to_string();
+            text = text[prefix.len()..].trim();
+            break;
+        }
+    }
+
+    while !text.is_empty() {
+        let (owner, advance) = if let Some(idx) = text.find("'s ") {
+            (text[..idx].to_string(), idx + 3)
+        } else if let Some(idx) = text.find("s' ") {
+            (format!("{}s", &text[..idx]), idx + 3)
+        } else if let Some(idx) = text.find("' ") {
+            (text[..idx].to_string(), idx + 2)
+        } else {
+            (text.to_string(), text.len())
+        };
+
+        if base.is_empty() {
+            base = owner;
+        } else {
+            path_segments.push(owner);
+        }
+
+        text = text.get(advance..).unwrap_or_default().trim();
+    }
+
+    let path = if path_segments.is_empty() {
+        None
+    } else {
+        Some(path_segments.join("."))
+    };
+
+    (base, path)
+}
+
 /// A type alias representing an evaluated group member and its resolved display name.
 pub(crate) type EvaluatedMember<'a> = (&'a dyn TemplateEntity, Cow<'a, str>);
 
@@ -625,6 +1087,10 @@ impl TemplateEntity for GroupEntity<'_> {
     fn is_proper_noun_for(&self, viewer_id: &str) -> bool {
         self.single_leaf_member()
             .is_none_or(|m| m.is_proper_noun_for(viewer_id))
+    }
+
+    fn aliases(&self) -> Option<&[&str]> {
+        self.single_leaf_member().and_then(TemplateEntity::aliases)
     }
 }
 

--- a/src/models.rs
+++ b/src/models.rs
@@ -6,6 +6,22 @@ use std::collections::HashSet;
 /// The unique sentinel string used by the engine to temporarily force the Director Stance.
 pub const NULL_VIEWER: &str = "\0__MUD_PERSPECTIVE_NULL_VIEWER__\0";
 
+static PRONOUNS: phf::Set<&'static str> = phf::phf_set! {
+    "he", "him", "his", "himself",
+    "she", "her", "hers", "herself",
+    "it", "its", "itself",
+    "they", "them", "their", "theirs", "themselves",
+    "you", "your", "yours", "yourself", "yourselves",
+    "i", "me", "my", "mine", "myself",
+    "we", "us", "our", "ours", "ourselves",
+};
+
+static VIEWER_PRONOUNS: phf::Set<&'static str> = phf::phf_set! {
+    "you", "your", "yours", "yourself", "yourselves",
+    "i", "me", "my", "mine", "myself",
+    "we", "us", "our", "ours", "ourselves",
+};
+
 /// Represents the grammatical gender of an entity for correct pronoun resolution.
 ///
 /// The `Plural` variant is critical for supporting both literal swarms (e.g., "a pack of wolves")
@@ -363,41 +379,7 @@ impl<'a> RenderContext<'a> {
         &self,
         base_desc: &str,
     ) -> Option<Vec<(String, &'a dyn TemplateEntity)>> {
-        let is_pronoun = matches!(
-            base_desc,
-            "he" | "him"
-                | "his"
-                | "himself"
-                | "she"
-                | "her"
-                | "hers"
-                | "herself"
-                | "it"
-                | "its"
-                | "itself"
-                | "they"
-                | "them"
-                | "their"
-                | "theirs"
-                | "themselves"
-                | "you"
-                | "your"
-                | "yours"
-                | "yourself"
-                | "yourselves"
-                | "i"
-                | "me"
-                | "my"
-                | "mine"
-                | "myself"
-                | "we"
-                | "us"
-                | "our"
-                | "ours"
-                | "ourselves"
-        );
-
-        if !is_pronoun {
+        if !PRONOUNS.contains(base_desc) {
             return None;
         }
 
@@ -410,24 +392,7 @@ impl<'a> RenderContext<'a> {
                     || recent.flags.contains(RecentEntityFlags::IS_VIEWER_FORCED);
 
                 let matches_pro = if is_viewer {
-                    matches!(
-                        base_desc,
-                        "you"
-                            | "your"
-                            | "yours"
-                            | "yourself"
-                            | "yourselves"
-                            | "i"
-                            | "me"
-                            | "my"
-                            | "mine"
-                            | "myself"
-                            | "we"
-                            | "us"
-                            | "our"
-                            | "ours"
-                            | "ourselves"
-                    )
+                    VIEWER_PRONOUNS.contains(base_desc)
                 } else {
                     match base_desc {
                         "he" | "him" | "his" | "himself" => gender == Gender::Male && !is_plural,

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -5851,4 +5851,1176 @@ mod tests {
             "The Avengers assembles and defends itself."
         );
     }
+
+    #[test]
+    fn test_resolve_target_pronouns() {
+        let player = MockEntity {
+            id: "char_1".to_string(),
+            name: "Aldran".to_string(),
+            gender: Gender::Male,
+            is_plural: false,
+            is_proper_noun: true,
+        };
+        let goblin = MockEntity {
+            id: "mob_1".to_string(),
+            name: "goblin".to_string(),
+            gender: Gender::Neutral,
+            is_plural: false,
+            is_proper_noun: false,
+        };
+        let wolves = MockEntity {
+            id: "mob_2".to_string(),
+            name: "wolves".to_string(),
+            gender: Gender::Plural,
+            is_plural: true,
+            is_proper_noun: false,
+        };
+
+        let ctx = RenderContext::new("char_1")
+            .with_entity("player", &player)
+            .with_entity("goblin", &goblin)
+            .with_entity("wolves", &wolves)
+            .with_last_mentioned("player")
+            .with_last_mentioned("goblin")
+            .with_last_mentioned("wolves");
+
+        // Singular male (but viewer)
+        let matches = ctx.resolve_target("me");
+        assert_eq!(matches.len(), 1);
+        assert_eq!(matches[0].key, "player");
+
+        let matches = ctx.resolve_target("you");
+        assert_eq!(matches.len(), 1);
+        assert_eq!(matches[0].key, "player");
+
+        // Neutral singular
+        let matches = ctx.resolve_target("it");
+        assert_eq!(matches.len(), 1);
+        assert_eq!(matches[0].key, "goblin");
+
+        // Plural
+        let matches = ctx.resolve_target("them");
+        assert_eq!(matches.len(), 1);
+        assert_eq!(matches[0].key, "wolves");
+    }
+
+    #[test]
+    fn test_resolve_target_names_and_ordinals() {
+        let wolf1 = MockEntity {
+            id: "w1".to_string(),
+            name: "wolf".to_string(),
+            gender: Gender::Neutral,
+            is_plural: false,
+            is_proper_noun: false,
+        };
+        let wolf2 = MockEntity {
+            id: "w2".to_string(),
+            name: "wolf".to_string(),
+            gender: Gender::Neutral,
+            is_plural: false,
+            is_proper_noun: false,
+        };
+        let orc = MockEntity {
+            id: "mob_1".to_string(),
+            name: "orc".to_string(),
+            gender: Gender::Male,
+            is_plural: false,
+            is_proper_noun: false,
+        };
+
+        let ctx = RenderContext::new("viewer")
+            .with_entity("w1", &wolf1)
+            .with_entity("w2", &wolf2)
+            .with_entity("orc", &orc);
+
+        // Pre-populate ordinals
+        let cache = TemplateCache::new(100);
+        let t = cache
+            .get_or_compile("{A:w1}, {a:orc}, and {a:w2} arrive.")
+            .unwrap();
+        PerspectiveEngine::render(&t, &ctx).unwrap();
+
+        // Exact match via name
+        let matches = ctx.resolve_target("the orc");
+        assert_eq!(matches.len(), 1);
+        assert_eq!(matches[0].key, "orc");
+
+        // Ordinals
+        let matches = ctx.resolve_target("the first wolf");
+        assert_eq!(matches.len(), 1);
+        assert_eq!(matches[0].key, "w1");
+
+        let matches = ctx.resolve_target("the 2nd wolf");
+        assert_eq!(matches.len(), 1);
+        assert_eq!(matches[0].key, "w2");
+
+        // Ambiguous match
+        let matches = ctx.resolve_target("a wolf");
+        assert_eq!(matches.len(), 2);
+        let mut keys: Vec<_> = matches.iter().map(|m| m.key.clone()).collect();
+        keys.sort();
+        assert_eq!(keys, vec!["w1", "w2"]);
+    }
+
+    #[test]
+    fn test_resolve_target_sub_elements() {
+        struct Weapon {
+            name: String,
+        }
+        impl TemplateEntity for Weapon {
+            fn contains_viewer(&self, _: &str) -> bool {
+                false
+            }
+            fn gender(&self) -> Gender {
+                Gender::Neutral
+            }
+            fn is_plural(&self) -> bool {
+                false
+            }
+            fn is_proper_noun_for(&self, _: &str) -> bool {
+                false
+            }
+            fn display_name_for<'a>(&'a self, _: &str) -> Cow<'a, str> {
+                Cow::Borrowed(&self.name)
+            }
+        }
+
+        struct Actor {
+            name: String,
+            weapon: Weapon,
+        }
+        impl TemplateEntity for Actor {
+            fn contains_viewer(&self, viewer_id: &str) -> bool {
+                viewer_id == "char_1"
+            }
+            fn gender(&self) -> Gender {
+                Gender::Male
+            }
+            fn is_plural(&self) -> bool {
+                false
+            }
+            fn is_proper_noun_for(&self, _: &str) -> bool {
+                true
+            }
+            fn display_name_for<'a>(&'a self, _: &str) -> Cow<'a, str> {
+                Cow::Borrowed(&self.name)
+            }
+            fn get_property(&self, property_name: &str) -> Option<&dyn TemplateEntity> {
+                match property_name {
+                    "sword" => Some(&self.weapon),
+                    _ => None,
+                }
+            }
+        }
+
+        let player = Actor {
+            name: "Aldran".to_string(),
+            weapon: Weapon {
+                name: "rusty sword".to_string(),
+            },
+        };
+
+        let ctx = RenderContext::new("char_2").with_entity("aldran", &player);
+
+        // Possessive literal name
+        let matches = ctx.resolve_target("Aldran's sword");
+        assert_eq!(matches.len(), 1);
+        assert_eq!(matches[0].key, "aldran");
+        assert_eq!(matches[0].path.as_deref(), Some("sword"));
+        assert_eq!(matches[0].path_uncertain, false);
+        assert_eq!(
+            matches[0]
+                .resolve_deep_entity()
+                .unwrap()
+                .display_name_for("viewer"),
+            "rusty sword"
+        );
+
+        // Possessive literal name, missing path
+        let matches2 = ctx.resolve_target("Aldran's shield");
+        assert_eq!(matches2.len(), 1);
+        assert_eq!(matches2[0].key, "aldran");
+        assert_eq!(matches2[0].path.as_deref(), Some("shield"));
+        assert_eq!(matches2[0].path_uncertain, true); // Path uncertain
+        assert!(matches2[0].resolve_deep_entity().is_none());
+
+        // Possessive pronoun (needs seeded recent_entities)
+        let ctx = ctx.with_last_mentioned("aldran");
+        let matches3 = ctx.resolve_target("his sword");
+        assert_eq!(matches3.len(), 1);
+        assert_eq!(matches3[0].key, "aldran");
+        assert_eq!(matches3[0].path.as_deref(), Some("sword"));
+        assert_eq!(matches3[0].path_uncertain, false);
+    }
+
+    #[test]
+    fn test_resolve_target_nested_sub_elements() {
+        struct Hilt {
+            name: String,
+        }
+        impl TemplateEntity for Hilt {
+            fn contains_viewer(&self, _: &str) -> bool {
+                false
+            }
+            fn gender(&self) -> Gender {
+                Gender::Neutral
+            }
+            fn is_plural(&self) -> bool {
+                false
+            }
+            fn is_proper_noun_for(&self, _: &str) -> bool {
+                false
+            }
+            fn display_name_for<'a>(&'a self, _: &str) -> Cow<'a, str> {
+                Cow::Borrowed(&self.name)
+            }
+        }
+
+        struct Weapon {
+            name: String,
+            hilt: Hilt,
+        }
+        impl TemplateEntity for Weapon {
+            fn contains_viewer(&self, _: &str) -> bool {
+                false
+            }
+            fn gender(&self) -> Gender {
+                Gender::Neutral
+            }
+            fn is_plural(&self) -> bool {
+                false
+            }
+            fn is_proper_noun_for(&self, _: &str) -> bool {
+                false
+            }
+            fn display_name_for<'a>(&'a self, _: &str) -> Cow<'a, str> {
+                Cow::Borrowed(&self.name)
+            }
+            fn get_property(&self, property_name: &str) -> Option<&dyn TemplateEntity> {
+                match property_name {
+                    "hilt" => Some(&self.hilt),
+                    _ => None,
+                }
+            }
+        }
+
+        struct Actor {
+            name: String,
+            weapon: Weapon,
+        }
+        impl TemplateEntity for Actor {
+            fn contains_viewer(&self, viewer_id: &str) -> bool {
+                viewer_id == "char_1"
+            }
+            fn gender(&self) -> Gender {
+                Gender::Male
+            }
+            fn is_plural(&self) -> bool {
+                false
+            }
+            fn is_proper_noun_for(&self, _: &str) -> bool {
+                true
+            }
+            fn display_name_for<'a>(&'a self, _: &str) -> Cow<'a, str> {
+                Cow::Borrowed(&self.name)
+            }
+            fn get_property(&self, property_name: &str) -> Option<&dyn TemplateEntity> {
+                match property_name {
+                    "sword" => Some(&self.weapon),
+                    _ => None,
+                }
+            }
+        }
+
+        let player = Actor {
+            name: "Aldran".to_string(),
+            weapon: Weapon {
+                name: "rusty sword".to_string(),
+                hilt: Hilt {
+                    name: "leather hilt".to_string(),
+                },
+            },
+        };
+
+        let ctx = RenderContext::new("char_2").with_entity("aldran", &player);
+
+        // Chained possessives should iteratively build and resolve against a dot-notation path
+        let matches = ctx.resolve_target("Aldran's sword's hilt");
+        assert_eq!(matches.len(), 1);
+        assert_eq!(matches[0].key, "aldran");
+        assert_eq!(matches[0].path.as_deref(), Some("sword.hilt"));
+        assert_eq!(matches[0].path_uncertain, false);
+        assert_eq!(
+            matches[0]
+                .resolve_deep_entity()
+                .unwrap()
+                .display_name_for("viewer"),
+            "leather hilt"
+        );
+
+        // Chained possessive pronouns also work
+        let ctx2 = ctx.with_last_mentioned("aldran");
+        let matches2 = ctx2.resolve_target("his sword's hilt");
+        assert_eq!(matches2.len(), 1);
+        assert_eq!(matches2[0].key, "aldran");
+        assert_eq!(matches2[0].path.as_deref(), Some("sword.hilt"));
+        assert_eq!(matches2[0].path_uncertain, false);
+        assert_eq!(
+            matches2[0]
+                .resolve_deep_entity()
+                .unwrap()
+                .display_name_for("viewer"),
+            "leather hilt"
+        );
+
+        // Missing deep path results in uncertain match
+        let matches3 = ctx2.resolve_target("his sword's gem");
+        assert_eq!(matches3.len(), 1);
+        assert_eq!(matches3[0].key, "aldran");
+        assert_eq!(matches3[0].path.as_deref(), Some("sword.gem"));
+        assert_eq!(matches3[0].path_uncertain, true);
+        assert!(matches3[0].resolve_deep_entity().is_none());
+    }
+
+    #[test]
+    fn test_resolve_target_strip_articles() {
+        let orcs = MockEntity {
+            id: "mob_1".to_string(),
+            name: "orcs".to_string(),
+            gender: Gender::Plural,
+            is_plural: true,
+            is_proper_noun: false,
+        };
+
+        let ctx = RenderContext::new("viewer").with_entity("orcs", &orcs);
+
+        let matches = ctx.resolve_target("one of the orcs");
+        assert_eq!(matches.len(), 1);
+        assert_eq!(matches[0].key, "orcs");
+
+        let matches = ctx.resolve_target("some orcs");
+        assert_eq!(matches.len(), 1);
+        assert_eq!(matches[0].key, "orcs");
+    }
+
+    #[test]
+    fn test_resolve_target_entity_names_with_articles() {
+        let avengers = MockEntity {
+            id: "char_1".to_string(),
+            name: "the Avengers".to_string(),
+            gender: Gender::Plural,
+            is_plural: true,
+            is_proper_noun: true,
+        };
+
+        let shiny_key = MockEntity {
+            id: "item_1".to_string(),
+            name: "a shiny key".to_string(),
+            gender: Gender::Neutral,
+            is_plural: false,
+            is_proper_noun: false,
+        };
+
+        let ctx = RenderContext::new("viewer")
+            .with_entity("avengers", &avengers)
+            .with_entity("key", &shiny_key);
+
+        // Player inputs without articles:
+        let m1 = ctx.resolve_target("avengers");
+        assert_eq!(m1.len(), 1);
+        assert_eq!(m1[0].key, "avengers");
+
+        let m2 = ctx.resolve_target("the avengers");
+        assert_eq!(m2.len(), 1);
+        assert_eq!(m2[0].key, "avengers");
+
+        let m3 = ctx.resolve_target("shiny key");
+        assert_eq!(m3.len(), 1);
+        assert_eq!(m3[0].key, "key");
+
+        let m4 = ctx.resolve_target("the shiny key");
+        assert_eq!(m4.len(), 1);
+        assert_eq!(m4[0].key, "key");
+    }
+
+    #[test]
+    fn test_resolve_target_ordinals_with_embedded_articles() {
+        let ring1 = MockEntity {
+            id: "r1".to_string(),
+            name: "a ring".to_string(),
+            gender: Gender::Neutral,
+            is_plural: false,
+            is_proper_noun: false,
+        };
+        let ring2 = MockEntity {
+            id: "r2".to_string(),
+            name: "a ring".to_string(),
+            gender: Gender::Neutral,
+            is_plural: false,
+            is_proper_noun: false,
+        };
+
+        let ctx = RenderContext::new("viewer")
+            .with_entity("r1", &ring1)
+            .with_entity("r2", &ring2);
+
+        let cache = TemplateCache::new(100);
+        let t = cache.get_or_compile("{r1} and {r2} are here.").unwrap();
+        PerspectiveEngine::render(&t, &ctx).unwrap(); // Seeds ordinals
+
+        let m1 = ctx.resolve_target("first ring");
+        assert_eq!(m1.len(), 1);
+        assert_eq!(m1[0].key, "r1");
+    }
+
+    #[test]
+    fn test_resolve_target_long_descriptions() {
+        let wolf_normal = ConfigurableMockEntity {
+            id: "w1".into(),
+            name: "wolf".into(),
+            long_name: None,
+            gender: Gender::Neutral,
+        };
+        let wolf_dire = ConfigurableMockEntity {
+            id: "w2".into(),
+            name: "wolf".into(),
+            long_name: Some("dire wolf".into()),
+            gender: Gender::Neutral,
+        };
+
+        let ctx = RenderContext::new("viewer")
+            .with_entity("w1", &wolf_normal)
+            .with_entity("w2", &wolf_dire);
+
+        // Match by short name (ambiguous)
+        let matches_short = ctx.resolve_target("wolf");
+        assert_eq!(matches_short.len(), 2);
+
+        // Match by long name (unambiguous)
+        let matches_long = ctx.resolve_target("dire wolf");
+        assert_eq!(matches_long.len(), 1);
+        assert_eq!(matches_long[0].key, "w2");
+
+        // Match by long name with an article
+        let matches_long_art = ctx.resolve_target("the dire wolf");
+        assert_eq!(matches_long_art.len(), 1);
+        assert_eq!(matches_long_art[0].key, "w2");
+    }
+
+    #[test]
+    fn test_resolve_target_ordinals_with_long_descriptions() {
+        let w_normal = ConfigurableMockEntity {
+            id: "w_normal".into(),
+            name: "wolf".into(),
+            long_name: None,
+            gender: Gender::Neutral,
+        };
+        let dw1 = ConfigurableMockEntity {
+            id: "dw1".into(),
+            name: "wolf".into(),
+            long_name: Some("dire wolf".into()),
+            gender: Gender::Neutral,
+        };
+        let dw2 = ConfigurableMockEntity {
+            id: "dw2".into(),
+            name: "wolf".into(),
+            long_name: Some("dire wolf".into()),
+            gender: Gender::Neutral,
+        };
+
+        let ctx = RenderContext::new("viewer")
+            .with_entity("w_normal", &w_normal)
+            .with_entity("dw1", &dw1)
+            .with_entity("dw2", &dw2);
+
+        let cache = TemplateCache::new(100);
+        // Render a template to seed the ordinal state. Because their short names ("wolf") collide
+        // with w_normal, their long names ("dire wolf") have fewer collisions, so the engine will
+        // their long name and assign ordinals.
+        let t = cache
+            .get_or_compile("{A:w_normal}, {a:dw1}, and {a:dw2} arrive.")
+            .unwrap();
+        PerspectiveEngine::render(&t, &ctx).unwrap();
+
+        let m1 = ctx.resolve_target("the first dire wolf");
+        assert_eq!(m1.len(), 1);
+        assert_eq!(m1[0].key, "dw1");
+
+        let m2 = ctx.resolve_target("the 2nd dire wolf");
+        assert_eq!(m2.len(), 1);
+        assert_eq!(m2[0].key, "dw2");
+
+        // Ambiguous match without the ordinal
+        let m3 = ctx.resolve_target("the dire wolf");
+        assert_eq!(m3.len(), 2);
+    }
+
+    #[test]
+    fn test_resolve_target_group_entities() {
+        let p1 = MockEntity {
+            id: "char_1".into(),
+            name: "Aldran".into(),
+            gender: Gender::Male,
+            is_plural: false,
+            is_proper_noun: true,
+        };
+        let p2 = MockEntity {
+            id: "char_2".into(),
+            name: "Bob".into(),
+            gender: Gender::Male,
+            is_plural: false,
+            is_proper_noun: true,
+        };
+
+        let party = GroupEntity::new(vec![&p1, &p2]);
+
+        let ctx = RenderContext::new("viewer")
+            .with_entity("party", &party)
+            .with_last_mentioned("party");
+
+        // Match by plural pronoun
+        let m1 = ctx.resolve_target("them");
+        assert_eq!(m1.len(), 1);
+        assert_eq!(m1[0].key, "party");
+
+        // Match by literal generated group name
+        let m2 = ctx.resolve_target("Aldran and Bob");
+        assert_eq!(m2.len(), 1);
+        assert_eq!(m2[0].key, "party");
+    }
+
+    #[test]
+    fn test_resolve_target_aliases() {
+        struct AliasActor {
+            name: &'static str,
+            alias_list: Vec<&'static str>,
+        }
+
+        impl TemplateEntity for AliasActor {
+            fn contains_viewer(&self, _: &str) -> bool {
+                false
+            }
+            fn gender(&self) -> Gender {
+                Gender::Male
+            }
+            fn is_plural(&self) -> bool {
+                false
+            }
+            fn is_proper_noun_for(&self, _: &str) -> bool {
+                true
+            }
+            fn display_name_for<'a>(&'a self, _: &str) -> Cow<'a, str> {
+                Cow::Borrowed(self.name)
+            }
+            fn aliases(&self) -> Option<&[&str]> {
+                Some(&self.alias_list)
+            }
+        }
+
+        let boss = AliasActor {
+            name: "Lord Aldran",
+            alias_list: vec!["Aldran", "the dark lord", "boss"],
+        };
+
+        let ctx = RenderContext::new("viewer").with_entity("boss", &boss);
+
+        assert_eq!(ctx.resolve_target("lord aldran").len(), 1);
+
+        assert_eq!(ctx.resolve_target("aldran").len(), 1);
+        assert_eq!(ctx.resolve_target("dark lord").len(), 1); // Also verifies article stripping works
+        assert_eq!(ctx.resolve_target("boss").len(), 1);
+        assert_eq!(ctx.resolve_target("the boss").len(), 1);
+
+        assert_eq!(ctx.resolve_target("king").len(), 0);
+
+        // Verify that partial substring matches do not falsely trigger alias resolution
+        assert_eq!(ctx.resolve_target("dark").len(), 0);
+        assert_eq!(ctx.resolve_target("lord").len(), 0); // "lord" is in "dark lord" and "Lord Aldran", but not an exact match
+        assert_eq!(ctx.resolve_target("the dark").len(), 0);
+    }
+
+    #[test]
+    fn test_group_entity_aliases() {
+        struct AliasActor {
+            name: &'static str,
+            alias_list: Vec<&'static str>,
+        }
+
+        impl TemplateEntity for AliasActor {
+            fn contains_viewer(&self, _: &str) -> bool {
+                false
+            }
+            fn gender(&self) -> Gender {
+                Gender::Male
+            }
+            fn is_plural(&self) -> bool {
+                false
+            }
+            fn is_proper_noun_for(&self, _: &str) -> bool {
+                true
+            }
+            fn display_name_for<'a>(&'a self, _: &str) -> Cow<'a, str> {
+                Cow::Borrowed(self.name)
+            }
+            fn aliases(&self) -> Option<&[&str]> {
+                Some(&self.alias_list)
+            }
+        }
+
+        let boss = AliasActor {
+            name: "Lord Aldran",
+            alias_list: vec!["Aldran", "the dark lord", "boss"],
+        };
+
+        let group = GroupEntity::new(vec![&boss]);
+        let ctx = RenderContext::new("viewer").with_entity("group", &group);
+
+        assert_eq!(ctx.resolve_target("dark lord").len(), 1);
+        assert_eq!(ctx.resolve_target("dark lord")[0].key, "group");
+    }
+
+    #[test]
+    fn test_resolve_target_ambiguous_multiple_matches() {
+        struct GuardActor {
+            name: &'static str,
+            gender: Gender,
+            alias_list: Vec<&'static str>,
+        }
+
+        impl TemplateEntity for GuardActor {
+            fn contains_viewer(&self, _: &str) -> bool {
+                false
+            }
+            fn gender(&self) -> Gender {
+                self.gender
+            }
+            fn is_plural(&self) -> bool {
+                false
+            }
+            fn is_proper_noun_for(&self, _: &str) -> bool {
+                false
+            }
+            fn display_name_for<'a>(&'a self, _: &str) -> Cow<'a, str> {
+                Cow::Borrowed(self.name)
+            }
+            fn aliases(&self) -> Option<&[&str]> {
+                Some(&self.alias_list)
+            }
+        }
+
+        let guard1 = GuardActor {
+            name: "tall guard",
+            gender: Gender::Male,
+            alias_list: vec!["guard", "watchman"],
+        };
+        let guard2 = GuardActor {
+            name: "short guard",
+            gender: Gender::Male,
+            alias_list: vec!["guard", "patrol"],
+        };
+
+        let ctx = RenderContext::new("viewer")
+            .with_entity("g1", &guard1)
+            .with_entity("g2", &guard2)
+            // Seed anaphora memory so pronouns evaluate against both
+            .with_last_mentioned("g1")
+            .with_last_mentioned("g2");
+
+        // 1. Ambiguous Pronoun (Both are Male)
+        let matches_pro = ctx.resolve_target("him");
+        assert_eq!(matches_pro.len(), 2);
+
+        // 2. Ambiguous Alias ("guard" is shared)
+        let matches_alias = ctx.resolve_target("the guard");
+        assert_eq!(matches_alias.len(), 2);
+
+        // Unambiguous Alias (for sanity)
+        let matches_unambig = ctx.resolve_target("the watchman");
+        assert_eq!(matches_unambig.len(), 1);
+        assert_eq!(matches_unambig[0].key, "g1");
+    }
+
+    #[test]
+    fn test_resolve_target_ambiguous_sub_elements() {
+        struct Item {
+            name: &'static str,
+        }
+        impl TemplateEntity for Item {
+            fn contains_viewer(&self, _: &str) -> bool {
+                false
+            }
+            fn gender(&self) -> Gender {
+                Gender::Neutral
+            }
+            fn is_plural(&self) -> bool {
+                false
+            }
+            fn is_proper_noun_for(&self, _: &str) -> bool {
+                false
+            }
+            fn display_name_for<'a>(&'a self, _: &str) -> Cow<'a, str> {
+                Cow::Borrowed(self.name)
+            }
+        }
+
+        struct Mob {
+            name: &'static str,
+            sword: Option<Item>,
+        }
+        impl TemplateEntity for Mob {
+            fn contains_viewer(&self, _: &str) -> bool {
+                false
+            }
+            fn gender(&self) -> Gender {
+                Gender::Male
+            }
+            fn is_plural(&self) -> bool {
+                false
+            }
+            fn is_proper_noun_for(&self, _: &str) -> bool {
+                false
+            }
+            fn display_name_for<'a>(&'a self, _: &str) -> Cow<'a, str> {
+                Cow::Borrowed(self.name)
+            }
+            fn get_property(&self, property_name: &str) -> Option<&dyn TemplateEntity> {
+                if property_name == "sword" {
+                    self.sword.as_ref().map(|s| s as &dyn TemplateEntity)
+                } else {
+                    None
+                }
+            }
+        }
+
+        let guard1 = Mob {
+            name: "guard",
+            sword: Some(Item { name: "iron sword" }),
+        };
+        let guard2 = Mob {
+            name: "guard",
+            sword: Some(Item {
+                name: "steel sword",
+            }),
+        };
+
+        let thief1 = Mob {
+            name: "thief",
+            sword: None,
+        };
+        let thief2 = Mob {
+            name: "thief",
+            sword: None,
+        };
+
+        let orc1 = Mob {
+            name: "orc",
+            sword: Some(Item {
+                name: "rusty sword",
+            }),
+        };
+        let orc2 = Mob {
+            name: "orc",
+            sword: None,
+        };
+
+        let ctx = RenderContext::new("viewer")
+            .with_entity("g1", &guard1)
+            .with_entity("g2", &guard2)
+            .with_entity("t1", &thief1)
+            .with_entity("t2", &thief2)
+            .with_entity("o1", &orc1)
+            .with_entity("o2", &orc2);
+
+        // 1. Both have the sub-element
+        let mut m_guard = ctx.resolve_target("the guard's sword");
+        assert_eq!(m_guard.len(), 2);
+        m_guard.sort_by_key(|m| m.key.clone());
+        assert_eq!(m_guard[0].key, "g1");
+        assert_eq!(m_guard[0].path_uncertain, false);
+        assert_eq!(m_guard[1].key, "g2");
+        assert_eq!(m_guard[1].path_uncertain, false);
+
+        // 2. Neither has the sub-element
+        let mut m_thief = ctx.resolve_target("the thief's sword");
+        assert_eq!(m_thief.len(), 2);
+        m_thief.sort_by_key(|m| m.key.clone());
+        assert_eq!(m_thief[0].key, "t1");
+        assert_eq!(m_thief[0].path_uncertain, true);
+        assert_eq!(m_thief[1].key, "t2");
+        assert_eq!(m_thief[1].path_uncertain, true);
+
+        // 3. One has it, the other doesn't
+        let mut m_orc = ctx.resolve_target("the orc's sword");
+        assert_eq!(m_orc.len(), 2);
+        m_orc.sort_by_key(|m| m.key.clone());
+        assert_eq!(m_orc[0].key, "o1");
+        assert_eq!(m_orc[0].path_uncertain, false); // o1 has it!
+        assert_eq!(m_orc[1].key, "o2");
+        assert_eq!(m_orc[1].path_uncertain, true); // o2 does not!
+    }
+
+    #[test]
+    fn test_resolve_target_ordinals_with_sub_elements() {
+        struct Item {
+            name: &'static str,
+        }
+        impl TemplateEntity for Item {
+            fn contains_viewer(&self, _: &str) -> bool {
+                false
+            }
+            fn gender(&self) -> Gender {
+                Gender::Neutral
+            }
+            fn is_plural(&self) -> bool {
+                false
+            }
+            fn is_proper_noun_for(&self, _: &str) -> bool {
+                false
+            }
+            fn display_name_for<'a>(&'a self, _: &str) -> Cow<'a, str> {
+                Cow::Borrowed(self.name)
+            }
+        }
+
+        struct Mob {
+            name: &'static str,
+            sword: Option<Item>,
+        }
+        impl TemplateEntity for Mob {
+            fn contains_viewer(&self, _: &str) -> bool {
+                false
+            }
+            fn gender(&self) -> Gender {
+                Gender::Male
+            }
+            fn is_plural(&self) -> bool {
+                false
+            }
+            fn is_proper_noun_for(&self, _: &str) -> bool {
+                false
+            }
+            fn display_name_for<'a>(&'a self, _: &str) -> Cow<'a, str> {
+                Cow::Borrowed(self.name)
+            }
+            fn get_property(&self, property_name: &str) -> Option<&dyn TemplateEntity> {
+                if property_name == "sword" {
+                    self.sword.as_ref().map(|s| s as &dyn TemplateEntity)
+                } else {
+                    None
+                }
+            }
+        }
+
+        let orc1 = Mob {
+            name: "orc",
+            sword: Some(Item {
+                name: "rusty sword",
+            }),
+        };
+        let orc2 = Mob {
+            name: "orc",
+            sword: None,
+        };
+
+        let ctx = RenderContext::new("viewer")
+            .with_entity("o1", &orc1)
+            .with_entity("o2", &orc2);
+
+        // Seed the ordinals by rendering a template
+        let cache = TemplateCache::new(100);
+        let t = cache.get_or_compile("{A:o1} and {a:o2} arrive.").unwrap();
+        PerspectiveEngine::render(&t, &ctx).unwrap();
+
+        let m1 = ctx.resolve_target("the first orc's sword");
+        assert_eq!(m1.len(), 1);
+        assert_eq!(m1[0].key, "o1");
+        assert_eq!(m1[0].path_uncertain, false); // o1 has the sword!
+
+        let m2 = ctx.resolve_target("the second orc's sword");
+        assert_eq!(m2.len(), 1);
+        assert_eq!(m2[0].key, "o2");
+        assert_eq!(m2[0].path_uncertain, true); // o2 does not have the sword!
+    }
+
+    #[test]
+    fn test_resolve_target_strict() {
+        struct Item {
+            name: &'static str,
+        }
+        impl TemplateEntity for Item {
+            fn contains_viewer(&self, _: &str) -> bool {
+                false
+            }
+            fn gender(&self) -> Gender {
+                Gender::Neutral
+            }
+            fn is_plural(&self) -> bool {
+                false
+            }
+            fn is_proper_noun_for(&self, _: &str) -> bool {
+                false
+            }
+            fn display_name_for<'a>(&'a self, _: &str) -> Cow<'a, str> {
+                Cow::Borrowed(self.name)
+            }
+        }
+
+        struct Mob {
+            name: &'static str,
+            sword: Option<Item>,
+        }
+        impl TemplateEntity for Mob {
+            fn contains_viewer(&self, _: &str) -> bool {
+                false
+            }
+            fn gender(&self) -> Gender {
+                Gender::Male
+            }
+            fn is_plural(&self) -> bool {
+                false
+            }
+            fn is_proper_noun_for(&self, _: &str) -> bool {
+                false
+            }
+            fn display_name_for<'a>(&'a self, _: &str) -> Cow<'a, str> {
+                Cow::Borrowed(self.name)
+            }
+            fn get_property(&self, property_name: &str) -> Option<&dyn TemplateEntity> {
+                if property_name == "sword" {
+                    self.sword.as_ref().map(|s| s as &dyn TemplateEntity)
+                } else {
+                    None
+                }
+            }
+        }
+
+        let orc1 = Mob {
+            name: "orc",
+            sword: Some(Item {
+                name: "rusty sword",
+            }),
+        };
+        let orc2 = Mob {
+            name: "orc",
+            sword: None,
+        };
+
+        let ctx = RenderContext::new("viewer")
+            .with_entity("o1", &orc1)
+            .with_entity("o2", &orc2);
+
+        // Standard resolve_target returns both, including the uncertain one.
+        assert_eq!(ctx.resolve_target("the orc's sword").len(), 2);
+
+        // Strict resolve naturally filters out o2 because its `get_property` returned None!
+        let m_strict = ctx.resolve_target_strict("the orc's sword");
+        assert_eq!(m_strict.len(), 1);
+        assert_eq!(m_strict[0].key, "o1");
+        assert_eq!(m_strict[0].path_uncertain, false);
+    }
+
+    #[test]
+    fn test_resolve_target_shortcut_ordinals() {
+        let orc1 = MockEntity {
+            id: "o1".to_string(),
+            name: "orc".to_string(),
+            gender: Gender::Male,
+            is_plural: false,
+            is_proper_noun: false,
+        };
+        let orc2 = MockEntity {
+            id: "o2".to_string(),
+            name: "orc".to_string(),
+            gender: Gender::Male,
+            is_plural: false,
+            is_proper_noun: false,
+        };
+        let goblin = MockEntity {
+            id: "g1".to_string(),
+            name: "goblin".to_string(),
+            gender: Gender::Neutral,
+            is_plural: false,
+            is_proper_noun: false,
+        };
+
+        let ctx = RenderContext::new("viewer")
+            .with_entity("o1", &orc1)
+            .with_entity("o2", &orc2)
+            .with_entity("g1", &goblin);
+
+        let cache = TemplateCache::new(100);
+        let t = cache.get_or_compile("{A:o1} and {a:o2} arrive.").unwrap();
+        PerspectiveEngine::render(&t, &ctx).unwrap();
+
+        // 1. Postfix syntax for ambiguous items
+        let m1 = ctx.resolve_target("orc 1");
+        assert_eq!(m1.len(), 1);
+        assert_eq!(m1[0].key, "o1");
+
+        let m2 = ctx.resolve_target("orc 2");
+        assert_eq!(m2.len(), 1);
+        assert_eq!(m2[0].key, "o2");
+
+        let m_first = ctx.resolve_target("first orc");
+        assert_eq!(m_first.len(), 1);
+        assert_eq!(m_first[0].key, "o1");
+
+        // 2. Postfix syntax for unambiguous items (defaults to 1)
+        let m3 = ctx.resolve_target("goblin 1");
+        assert_eq!(m3.len(), 1);
+        assert_eq!(m3[0].key, "g1");
+
+        let m4 = ctx.resolve_target("first goblin");
+        assert_eq!(m4.len(), 1);
+        assert_eq!(m4[0].key, "g1");
+
+        let m5 = ctx.resolve_target("goblin 2");
+        assert_eq!(m5.len(), 0);
+    }
+
+    #[test]
+    fn test_e2e_combat_round() {
+        struct Weapon {
+            name: &'static str,
+        }
+        impl TemplateEntity for Weapon {
+            fn contains_viewer(&self, _: &str) -> bool {
+                false
+            }
+            fn gender(&self) -> Gender {
+                Gender::Neutral
+            }
+            fn is_plural(&self) -> bool {
+                false
+            }
+            fn is_proper_noun_for(&self, _: &str) -> bool {
+                false
+            }
+            fn display_name_for<'a>(&'a self, _: &str) -> Cow<'a, str> {
+                Cow::Borrowed(self.name)
+            }
+        }
+
+        struct Combatant {
+            id: &'static str,
+            name: &'static str,
+            gender: Gender,
+            is_proper_noun: bool,
+            weapon: Option<Weapon>,
+            aliases: &'static [&'static str],
+        }
+        impl TemplateEntity for Combatant {
+            fn contains_viewer(&self, viewer_id: &str) -> bool {
+                self.id == viewer_id
+            }
+            fn gender(&self) -> Gender {
+                self.gender
+            }
+            fn is_plural(&self) -> bool {
+                false
+            }
+            fn is_proper_noun_for(&self, _: &str) -> bool {
+                self.is_proper_noun
+            }
+            fn display_name_for<'a>(&'a self, viewer_id: &str) -> Cow<'a, str> {
+                if self.contains_viewer(viewer_id) {
+                    Cow::Borrowed("you")
+                } else {
+                    Cow::Borrowed(self.name)
+                }
+            }
+            fn get_property(&self, property_name: &str) -> Option<&dyn TemplateEntity> {
+                if property_name == "weapon" {
+                    self.weapon.as_ref().map(|w| w as &dyn TemplateEntity)
+                } else {
+                    None
+                }
+            }
+            fn aliases(&self) -> Option<&[&str]> {
+                Some(self.aliases)
+            }
+        }
+
+        let player = Combatant {
+            id: "char_1",
+            name: "Aldran",
+            gender: Gender::Male,
+            is_proper_noun: true,
+            weapon: Some(Weapon {
+                name: "glowing sword",
+            }),
+            aliases: &[],
+        };
+        let goblin1 = Combatant {
+            id: "mob_1",
+            name: "goblin",
+            gender: Gender::Neutral,
+            is_proper_noun: false,
+            weapon: Some(Weapon {
+                name: "rusty dagger",
+            }),
+            aliases: &["scout"],
+        };
+        let goblin2 = Combatant {
+            id: "mob_2",
+            name: "goblin",
+            gender: Gender::Neutral,
+            is_proper_noun: false,
+            weapon: Some(Weapon {
+                name: "wooden club",
+            }),
+            aliases: &["brute"], // Same base name to trigger ordinals
+        };
+
+        let cache = TemplateCache::new(100);
+        let ctx = RenderContext::new("char_1") // The player is the viewer
+            .with_entity("player", &player)
+            .with_entity("g1", &goblin1)
+            .with_entity("g2", &goblin2);
+
+        // 1. Render the encounter (Seeds Ordinals and Anaphora memory)
+        let t_intro = cache
+            .get_or_compile("{A:g1} and {a:g2} ambush {player}!")
+            .unwrap();
+        assert_eq!(
+            PerspectiveEngine::render(&t_intro, &ctx).unwrap(),
+            "A goblin and another goblin ambush you!"
+        );
+
+        // 2. Simulate Player Input: "attack the first goblin"
+        let targets = ctx.resolve_target("the first goblin");
+        assert_eq!(targets.len(), 1);
+        assert_eq!(targets[0].key, "g1");
+
+        // 3. Render the player's combat action
+        let t_attack = cache
+            .get_or_compile("{player} [player:slash] {the:g1} with {player:poss} {player.weapon}.")
+            .unwrap();
+        assert_eq!(
+            PerspectiveEngine::render(&t_attack, &ctx).unwrap(),
+            "You slash the first goblin with your glowing sword."
+        );
+
+        // 4. Enemy 2 retaliates
+        let t_retaliate = cache
+            .get_or_compile("{The:g2} [g2:swing] {g2:poss} {g2.weapon} at {player:obj}!")
+            .unwrap();
+        assert_eq!(
+            PerspectiveEngine::render(&t_retaliate, &ctx).unwrap(),
+            "The second goblin swings its wooden club at you!"
+        );
+
+        // 5. Simulate Player Input: "disarm brute's weapon" (Uses alias + sub-element path)
+        let targets_alias = ctx.resolve_target_strict("brute's weapon");
+        assert_eq!(targets_alias.len(), 1);
+        assert_eq!(targets_alias[0].key, "g2");
+        assert_eq!(targets_alias[0].path.as_deref(), Some("weapon"));
+
+        let nested_item = targets_alias[0].resolve_deep_entity().unwrap();
+        assert_eq!(nested_item.display_name_for("viewer"), "wooden club");
+
+        // 6. Simulate Player Input: "attack it" (Ambiguous pronoun, both neutral goblins are in memory)
+        let targets_pronoun = ctx.resolve_target("it");
+        assert_eq!(targets_pronoun.len(), 2);
+    }
 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,5 +1,4 @@
 #[cfg(test)]
-#[allow(clippy::unwrap_used)]
 #[allow(clippy::indexing_slicing)]
 mod tests {
     use crate::cache::TemplateCache;
@@ -81,16 +80,18 @@ mod tests {
         // Note: We use lowercase text. The post-processor will handle capitalization safely.
         let template =
             Template::compile("{source} [source:be] looking around for {source:poss} sword.")
-                .unwrap();
+                .expect("Failed to compile template");
 
         // 1. Actor Stance (Aldran is the viewer)
         let ctx_actor = RenderContext::new("char_1").with_entity("source", &aldran);
-        let actor_output = PerspectiveEngine::render(&template, &ctx_actor).unwrap();
+        let actor_output =
+            PerspectiveEngine::render(&template, &ctx_actor).expect("Failed to render template");
         assert_eq!(actor_output, "You are looking around for your sword.");
 
         // 2. Director Stance (A third-party observer)
         let ctx_director = RenderContext::new("char_2").with_entity("source", &aldran);
-        let director_output = PerspectiveEngine::render(&template, &ctx_director).unwrap();
+        let director_output =
+            PerspectiveEngine::render(&template, &ctx_director).expect("Failed to render template");
         assert_eq!(director_output, "Aldran is looking around for his sword.");
     }
 
@@ -104,10 +105,12 @@ mod tests {
             is_proper_noun: true, // is_proper_noun_for returns false for strangers
         };
 
-        let template = Template::compile("{a:source} [source:approach].").unwrap();
+        let template =
+            Template::compile("{a:source} [source:approach].").expect("Failed to compile template");
 
         let ctx_stranger = RenderContext::new("stranger_1").with_entity("source", &aldran);
-        let stranger_output = PerspectiveEngine::render(&template, &ctx_stranger).unwrap();
+        let stranger_output =
+            PerspectiveEngine::render(&template, &ctx_stranger).expect("Failed to render template");
 
         // The engine should dynamically add the article "a", and capitalize the sentence
         assert_eq!(stranger_output, "A tall man approaches.");
@@ -134,36 +137,43 @@ mod tests {
         let cache = TemplateCache::new(100);
 
         // --- SCENARIO 1: `{the:key}` on a common noun ---
-        let template_the = cache.get_or_compile("{the:source} is here.").unwrap();
-        let output_the = render_msg!("char_2", &template_the, "source" => &goblin).unwrap();
+        let template_the = cache
+            .get_or_compile("{the:source} is here.")
+            .expect("Failed to compile template");
+        let output_the = render_msg!("char_2", &template_the, "source" => &goblin)
+            .expect("Failed to render template");
         assert_eq!(output_the, "The goblin is here.");
 
         // --- SCENARIO 2: `{a:key}` suppressed for a proper noun ---
-        let template_a_proper = cache.get_or_compile("{a:source} is here.").unwrap();
-        let output_a_proper =
-            render_msg!("char_2", &template_a_proper, "source" => &aldran).unwrap();
+        let template_a_proper = cache
+            .get_or_compile("{a:source} is here.")
+            .expect("Failed to compile template");
+        let output_a_proper = render_msg!("char_2", &template_a_proper, "source" => &aldran)
+            .expect("Failed to render template");
         assert_eq!(output_a_proper, "Aldran is here.");
 
         // --- SCENARIO 3: `{the:key}` suppressed for a proper noun ---
-        let template_the_proper = cache.get_or_compile("{the:source} is here.").unwrap();
-        let output_the_proper =
-            render_msg!("char_2", &template_the_proper, "source" => &aldran).unwrap();
+        let template_the_proper = cache
+            .get_or_compile("{the:source} is here.")
+            .expect("Failed to compile template");
+        let output_the_proper = render_msg!("char_2", &template_the_proper, "source" => &aldran)
+            .expect("Failed to render template");
         assert_eq!(output_the_proper, "Aldran is here.");
 
         // --- SCENARIO 4: `{a:key}` suppressed for the viewer ---
         let template_a_viewer = cache
             .get_or_compile("{a:source} [source:be] here.")
-            .unwrap();
-        let output_a_viewer =
-            render_msg!("char_1", &template_a_viewer, "source" => &aldran).unwrap();
+            .expect("Failed to compile template");
+        let output_a_viewer = render_msg!("char_1", &template_a_viewer, "source" => &aldran)
+            .expect("Failed to render template");
         assert_eq!(output_a_viewer, "You are here.");
 
         // --- SCENARIO 5: `{the:key}` suppressed for the viewer ---
         let template_the_viewer = cache
             .get_or_compile("{the:source} [source:be] here.")
-            .unwrap();
-        let output_the_viewer =
-            render_msg!("char_1", &template_the_viewer, "source" => &aldran).unwrap();
+            .expect("Failed to compile template");
+        let output_the_viewer = render_msg!("char_1", &template_the_viewer, "source" => &aldran)
+            .expect("Failed to render template");
         assert_eq!(output_the_viewer, "You are here.");
 
         // --- SCENARIO 6: Plural proper nouns (e.g. "The Smiths", "The Avengers") ---
@@ -178,15 +188,19 @@ mod tests {
         };
 
         // Indefinite article "a" is suppressed, leaving the base name "the Avengers" (capitalized by typography)
-        let template_a_plural = cache.get_or_compile("{a:source} assemble!").unwrap();
-        let output_a_plural =
-            render_msg!("char_2", &template_a_plural, "source" => &avengers).unwrap();
+        let template_a_plural = cache
+            .get_or_compile("{a:source} assemble!")
+            .expect("Failed to compile template");
+        let output_a_plural = render_msg!("char_2", &template_a_plural, "source" => &avengers)
+            .expect("Failed to render template");
         assert_eq!(output_a_plural, "The Avengers assemble!");
 
         // Definite article "the" is suppressed, leaving the base name "the Avengers"
-        let template_the_plural = cache.get_or_compile("{The:source} assemble!").unwrap();
-        let output_the_plural =
-            render_msg!("char_2", &template_the_plural, "source" => &avengers).unwrap();
+        let template_the_plural = cache
+            .get_or_compile("{The:source} assemble!")
+            .expect("Failed to compile template");
+        let output_the_plural = render_msg!("char_2", &template_the_plural, "source" => &avengers)
+            .expect("Failed to render template");
         assert_eq!(output_the_plural, "The Avengers assemble!");
 
         // --- SCENARIO 7: Plural common nouns (e.g. "wolves") ---
@@ -199,15 +213,21 @@ mod tests {
         };
 
         // Indefinite article "a" should evaluate to "some" for plural common nouns
-        let template_a_common_plural = cache.get_or_compile("{a:source} howl.").unwrap();
+        let template_a_common_plural = cache
+            .get_or_compile("{a:source} howl.")
+            .expect("Failed to compile template");
         let output_a_common_plural =
-            render_msg!("char_2", &template_a_common_plural, "source" => &wolves).unwrap();
+            render_msg!("char_2", &template_a_common_plural, "source" => &wolves)
+                .expect("Failed to render template");
         assert_eq!(output_a_common_plural, "Some wolves howl.");
 
         // Definite article "the" should NOT be suppressed for plural common nouns
-        let template_the_common_plural = cache.get_or_compile("{The:source} howl.").unwrap();
+        let template_the_common_plural = cache
+            .get_or_compile("{The:source} howl.")
+            .expect("Failed to compile template");
         let output_the_common_plural =
-            render_msg!("char_2", &template_the_common_plural, "source" => &wolves).unwrap();
+            render_msg!("char_2", &template_the_common_plural, "source" => &wolves)
+                .expect("Failed to render template");
         assert_eq!(output_the_common_plural, "The wolves howl.");
     }
 
@@ -265,14 +285,14 @@ mod tests {
         };
 
         // Testing the "active subject fallacy" fix by explicitly binding the verb to the wolves
-        let template =
-            Template::compile("the {target} watches as the {source} [source:attack]!").unwrap();
+        let template = Template::compile("the {target} watches as the {source} [source:attack]!")
+            .expect("Failed to compile template");
 
         let ctx = RenderContext::new("char_2")
             .with_entity("source", &wolves)
             .with_entity("target", &player);
 
-        let output = PerspectiveEngine::render(&template, &ctx).unwrap();
+        let output = PerspectiveEngine::render(&template, &ctx).expect("Failed to render template");
 
         // Because wolves are plural, the verb "attack" should NOT become "attacks",
         // even though it's evaluating in the third person.
@@ -330,20 +350,21 @@ mod tests {
         let cache = TemplateCache::new(100);
         let template = cache
             .get_or_compile("{the:target} [target:watch] as the {source} [source:attack]!")
-            .unwrap();
+            .expect("Failed to compile template");
 
         // BEFORE: The verbose, manual context building
         let manual_ctx = RenderContext::new("char_1")
             .with_entity("source", &wolves)
             .with_entity("target", &player);
-        let manual_output = PerspectiveEngine::render(&template, &manual_ctx).unwrap();
+        let manual_output =
+            PerspectiveEngine::render(&template, &manual_ctx).expect("Failed to render template");
 
         // AFTER: The clean, single-line macro approach
         let macro_output = render_msg!("char_1", &template,
             "source" => &wolves,
             "target" => &player,
         )
-        .unwrap();
+        .expect("Failed to render template");
 
         // Both should yield the exact same grammatically correct string
         assert_eq!(manual_output, "You watch as the pack of wolves attack!");
@@ -393,49 +414,53 @@ mod tests {
         // --- SCENARIO 1: Verbs & Display Names ---
         let template_action = cache
             .get_or_compile("{source} [source:open] the door.")
-            .unwrap();
+            .expect("Failed to compile template");
 
         // Viewer is IN the party -> Expects "you" injection and uninflected verb
-        let member_action = render_msg!("char_1", &template_action, "source" => &party).unwrap();
+        let member_action = render_msg!("char_1", &template_action, "source" => &party)
+            .expect("Failed to render template");
         assert_eq!(member_action, "You and Bob open the door.");
 
         // Viewer is OUTSIDE the party -> Expects 3rd-person names, but still an uninflected verb
-        let observer_action = render_msg!("char_3", &template_action, "source" => &party).unwrap();
+        let observer_action = render_msg!("char_3", &template_action, "source" => &party)
+            .expect("Failed to render template");
         assert_eq!(observer_action, "Aldran and Bob open the door.");
 
         // Oxford comma test for 3+ members
-        let observer_big = render_msg!("mob_1", &template_action, "source" => &big_party).unwrap();
+        let observer_big = render_msg!("mob_1", &template_action, "source" => &big_party)
+            .expect("Failed to render template");
         assert_eq!(observer_big, "Aldran, Bob, and Charlie open the door.");
 
         // --- SCENARIO 2: Group Pronouns ---
         let template_pronoun = cache
             .get_or_compile("{the:source} [source:attack] {target:obj}!")
-            .unwrap();
+            .expect("Failed to compile template");
 
         // The group is the target, viewer is IN the group -> Expects 2nd-person "you"
         let member_pronoun =
             render_msg!("char_1", &template_pronoun, "source" => &enemy, "target" => &party)
-                .unwrap();
+                .expect("Failed to render template");
         assert_eq!(member_pronoun, "The Goblin attacks you!");
 
         // The group is the target, viewer is OUTSIDE the group -> Expects 3rd-person plural "them"
         let observer_pronoun =
             render_msg!("char_3", &template_pronoun, "source" => &enemy, "target" => &party)
-                .unwrap();
+                .expect("Failed to render template");
         assert_eq!(observer_pronoun, "The Goblin attacks Aldran and Bob!");
 
         // --- SCENARIO 3: Article Suppression ---
         let template_article = cache
             .get_or_compile("{the:source} [source:be] ready.")
-            .unwrap();
+            .expect("Failed to compile template");
 
         // Viewer IN party -> suppresses article (starts with "You")
-        let member_article = render_msg!("char_1", &template_article, "source" => &party).unwrap();
+        let member_article = render_msg!("char_1", &template_article, "source" => &party)
+            .expect("Failed to render template");
         assert_eq!(member_article, "You and Bob are ready.");
 
         // Viewer OUTSIDE party -> suppresses article because the Group is treated as a proper noun
-        let observer_article =
-            render_msg!("char_3", &template_article, "source" => &party).unwrap();
+        let observer_article = render_msg!("char_3", &template_article, "source" => &party)
+            .expect("Failed to render template");
         assert_eq!(observer_article, "Aldran and Bob are ready.");
 
         // --- SCENARIO 4: Mixed Recognition (Internal Articles) ---
@@ -444,10 +469,10 @@ mod tests {
         };
         let template_mixed = cache
             .get_or_compile("{the:source} [source:prepare] for battle.")
-            .unwrap();
+            .expect("Failed to compile template");
 
-        let observer_mixed =
-            render_msg!("char_3", &template_mixed, "source" => &mixed_party).unwrap();
+        let observer_mixed = render_msg!("char_3", &template_mixed, "source" => &mixed_party)
+            .expect("Failed to render template");
         // "Aldran" is a proper noun (no article), "Goblin" is a common noun (gets "the").
         assert_eq!(observer_mixed, "Aldran and the Goblin prepare for battle.");
     }
@@ -521,11 +546,11 @@ mod tests {
             .get_or_compile(
                 "{the:source} [source:should] be careful, or {the:target} [target:might] attack.",
             )
-            .unwrap();
+            .expect("Failed to compile template");
 
         let observer_should =
             render_msg!("char_3", &template_should, "source" => &player, "target" => &wolves)
-                .unwrap();
+                .expect("Failed to render template");
         assert_eq!(
             observer_should,
             "Aldran should be careful, or the pack of wolves might attack."
@@ -534,79 +559,95 @@ mod tests {
 
     #[test]
     fn test_unclosed_tags_return_errors() {
-        let entity_err = Template::compile("The {source approaches.").unwrap_err();
+        let entity_err =
+            Template::compile("The {source approaches.").expect_err("Expected compilation to fail");
         assert_eq!(entity_err, "Unclosed entity tag starting at index 4");
 
-        let verb_err = Template::compile("The goblin [attack").unwrap_err();
+        let verb_err =
+            Template::compile("The goblin [attack").expect_err("Expected compilation to fail");
         assert_eq!(verb_err, "Unclosed verb tag starting at index 11");
     }
 
     #[test]
     fn test_malformed_tags_return_errors() {
-        let entity_err = Template::compile("The {a:b:c} approaches.").unwrap_err();
+        let entity_err =
+            Template::compile("The {a:b:c} approaches.").expect_err("Expected compilation to fail");
         assert_eq!(entity_err, "Malformed entity tag: {a:b:c}");
 
-        let verb_err = Template::compile("The goblin [a:b:c]").unwrap_err();
+        let verb_err =
+            Template::compile("The goblin [a:b:c]").expect_err("Expected compilation to fail");
         assert_eq!(verb_err, "Malformed verb tag: [a:b:c]");
     }
 
     #[test]
     fn test_empty_tag_parts_return_errors() {
-        let err1 = Template::compile("The {a:} approaches.").unwrap_err();
+        let err1 =
+            Template::compile("The {a:} approaches.").expect_err("Expected compilation to fail");
         assert_eq!(err1, "Entity tag has an article but an empty key: {a:}");
 
-        let err2 = Template::compile("The {the:} approaches.").unwrap_err();
+        let err2 =
+            Template::compile("The {the:} approaches.").expect_err("Expected compilation to fail");
         assert_eq!(err2, "Entity tag has an article but an empty key: {the:}");
 
-        let err3 = Template::compile("The goblin hits {:poss} shield.").unwrap_err();
+        let err3 = Template::compile("The goblin hits {:poss} shield.")
+            .expect_err("Expected compilation to fail");
         assert_eq!(err3, "Pronoun tag has an empty key or type: {:poss}");
 
-        let err4 = Template::compile("The goblin hits {source:}.").unwrap_err();
+        let err4 = Template::compile("The goblin hits {source:}.")
+            .expect_err("Expected compilation to fail");
         assert_eq!(err4, "Pronoun tag has an empty key or type: {source:}");
 
-        let err5 = Template::compile("A {} appears.").unwrap_err();
+        let err5 = Template::compile("A {} appears.").expect_err("Expected compilation to fail");
         assert_eq!(err5, "Entity tag has an empty key: {}");
 
-        let err6 = Template::compile("The goblin [:attack].").unwrap_err();
+        let err6 =
+            Template::compile("The goblin [:attack].").expect_err("Expected compilation to fail");
         assert_eq!(err6, "Verb tag has an empty subject key: [:attack]");
 
-        let err7 = Template::compile("You [source:be|].").unwrap_err();
+        let err7 =
+            Template::compile("You [source:be|].").expect_err("Expected compilation to fail");
         assert_eq!(
             err7,
             "Verb tag has an empty verb or forced conjugation segment: [source:be|]"
         );
 
-        let err8 = Template::compile("You [source:|be].").unwrap_err();
+        let err8 =
+            Template::compile("You [source:|be].").expect_err("Expected compilation to fail");
         assert_eq!(
             err8,
             "Verb tag has an empty verb or forced conjugation segment: [source:|be]"
         );
 
-        let err9 = Template::compile("You [source:be|am||is].").unwrap_err();
+        let err9 =
+            Template::compile("You [source:be|am||is].").expect_err("Expected compilation to fail");
         assert_eq!(
             err9,
             "Verb tag has an empty forced present conjugation segment: [source:be|am||is]"
         );
 
-        let err10 = Template::compile("You [source:be|am|are|is|were].").unwrap_err();
+        let err10 = Template::compile("You [source:be|am|are|is|were].")
+            .expect_err("Expected compilation to fail");
         assert_eq!(
             err10,
             "Verb tag has too many forced present conjugation segments: [source:be|am|are|is|were]"
         );
 
-        let err11 = Template::compile("You [source:be|am|are|is;].").unwrap_err();
+        let err11 = Template::compile("You [source:be|am|are|is;].")
+            .expect_err("Expected compilation to fail");
         assert_eq!(
             err11,
             "Verb tag has an empty forced past conjugation segment: [source:be|am|are|is;]"
         );
 
-        let err12 = Template::compile("You [source:be|;was||was].").unwrap_err();
+        let err12 = Template::compile("You [source:be|;was||was].")
+            .expect_err("Expected compilation to fail");
         assert_eq!(
             err12,
             "Verb tag has an empty forced past conjugation segment: [source:be|;was||was]"
         );
 
-        let err13 = Template::compile("You [source:be|am|are|is;was|were|was|were].").unwrap_err();
+        let err13 = Template::compile("You [source:be|am|are|is;was|were|was|were].")
+            .expect_err("Expected compilation to fail");
         assert_eq!(
             err13,
             "Verb tag has too many forced past conjugation segments: [source:be|am|are|is;was|were|was|were]"
@@ -636,24 +677,27 @@ mod tests {
         // 1. Two-part syntax (Base/Plural | 3rd Singular)
         let template_2 = cache
             .get_or_compile("{the:source} [source:freak out|freak out|freaks out].")
-            .unwrap();
+            .expect("Failed to compile template");
         assert_eq!(
-            render_msg!("char_1", &template_2, "source" => &player).unwrap(),
+            render_msg!("char_1", &template_2, "source" => &player)
+                .expect("Failed to render template"),
             "You freak out."
         );
         assert_eq!(
-            render_msg!("char_2", &template_2, "source" => &player).unwrap(),
+            render_msg!("char_2", &template_2, "source" => &player)
+                .expect("Failed to render template"),
             "Aldran freaks out."
         );
         assert_eq!(
-            render_msg!("char_2", &template_2, "source" => &wolves).unwrap(),
+            render_msg!("char_2", &template_2, "source" => &wolves)
+                .expect("Failed to render template"),
             "The wolves freak out."
         );
 
         // 2. Three-part syntax (1st Singular | 2nd/Plural | 3rd Singular)
         let template_3 = cache
             .get_or_compile("{the:source} [source:be|was|were|was] here.")
-            .unwrap();
+            .expect("Failed to compile template");
         let ctx_first = RenderContext::new("char_1")
             .with_stance(crate::models::ActorStance::FirstPerson)
             .with_entity("source", &player);
@@ -662,19 +706,19 @@ mod tests {
         let ctx_plural = RenderContext::new("char_2").with_entity("source", &wolves);
 
         assert_eq!(
-            PerspectiveEngine::render(&template_3, &ctx_first).unwrap(),
+            PerspectiveEngine::render(&template_3, &ctx_first).expect("Failed to render template"),
             "I was here."
         );
         assert_eq!(
-            PerspectiveEngine::render(&template_3, &ctx_second).unwrap(),
+            PerspectiveEngine::render(&template_3, &ctx_second).expect("Failed to render template"),
             "You were here."
         );
         assert_eq!(
-            PerspectiveEngine::render(&template_3, &ctx_third).unwrap(),
+            PerspectiveEngine::render(&template_3, &ctx_third).expect("Failed to render template"),
             "Aldran was here."
         );
         assert_eq!(
-            PerspectiveEngine::render(&template_3, &ctx_plural).unwrap(),
+            PerspectiveEngine::render(&template_3, &ctx_plural).expect("Failed to render template"),
             "The wolves were here."
         );
     }
@@ -694,15 +738,19 @@ mod tests {
         // --- TEST 1: "Be" -> "Is" ---
         // The post-processor will capitalize the 'A' of Aldran. The conjugation logic
         // should capitalize the 'I' of 'is' because the base verb "Be" is capitalized.
-        let template_be = cache.get_or_compile("{source} [source:Be] here.").unwrap();
-        let director_be = render_msg!("char_3", &template_be, "source" => &player).unwrap();
+        let template_be = cache
+            .get_or_compile("{source} [source:Be] here.")
+            .expect("Failed to compile template");
+        let director_be = render_msg!("char_3", &template_be, "source" => &player)
+            .expect("Failed to render template");
         assert_eq!(director_be, "Aldran Is here.");
 
         // --- TEST 2: "Have" -> "Has" ---
         let template_have = cache
             .get_or_compile("{source} [source:Have] a sword.")
-            .unwrap();
-        let director_have = render_msg!("char_3", &template_have, "source" => &player).unwrap();
+            .expect("Failed to compile template");
+        let director_have = render_msg!("char_3", &template_have, "source" => &player)
+            .expect("Failed to render template");
         assert_eq!(director_have, "Aldran Has a sword.");
     }
 
@@ -718,12 +766,18 @@ mod tests {
 
         let cache = TemplateCache::new(100);
 
-        let template_y = cache.get_or_compile("{source} [source:y].").unwrap();
-        let output_y = render_msg!("char_3", &template_y, "source" => &player).unwrap();
+        let template_y = cache
+            .get_or_compile("{source} [source:y].")
+            .expect("Failed to compile template");
+        let output_y = render_msg!("char_3", &template_y, "source" => &player)
+            .expect("Failed to render template");
         assert_eq!(output_y, "Aldran ys.");
 
-        let template_empty = cache.get_or_compile("{source} [source:].").unwrap();
-        let output_empty = render_msg!("char_3", &template_empty, "source" => &player).unwrap();
+        let template_empty = cache
+            .get_or_compile("{source} [source:].")
+            .expect("Failed to compile template");
+        let output_empty = render_msg!("char_3", &template_empty, "source" => &player)
+            .expect("Failed to render template");
         assert_eq!(output_empty, "Aldran s.");
     }
 
@@ -751,10 +805,11 @@ mod tests {
         let cache = TemplateCache::new(100);
         let template = cache
             .get_or_compile("{source} [source:defend] {source:reflex}!")
-            .unwrap();
+            .expect("Failed to compile template");
 
         // Plural Viewer (Actor Stance) -> tests the "yourselves" logic
-        let plural_actor = render_msg!("char_1", &template, "source" => &party).unwrap();
+        let plural_actor = render_msg!("char_1", &template, "source" => &party)
+            .expect("Failed to render template");
         assert_eq!(plural_actor, "You and Bob defend yourselves!");
     }
 
@@ -773,8 +828,9 @@ mod tests {
 
         let template_ansi = cache
             .get_or_compile("\x1b[31mthe {source} [source:attack].")
-            .unwrap();
-        let output_ansi = render_msg!("char_2", &template_ansi, "source" => &goblin).unwrap();
+            .expect("Failed to compile template");
+        let output_ansi = render_msg!("char_2", &template_ansi, "source" => &goblin)
+            .expect("Failed to render template");
         assert_eq!(output_ansi, "\x1b[31mThe goblin attacks.");
     }
 
@@ -793,8 +849,9 @@ mod tests {
 
         let template_mxp = cache
             .get_or_compile("<COLOR red>a {source} [source:approach].")
-            .unwrap();
-        let output_mxp = render_msg!("char_2", &template_mxp, "source" => &goblin).unwrap();
+            .expect("Failed to compile template");
+        let output_mxp = render_msg!("char_2", &template_mxp, "source" => &goblin)
+            .expect("Failed to render template");
         assert_eq!(output_mxp, "<COLOR red>A goblin approaches.");
     }
 
@@ -814,8 +871,9 @@ mod tests {
         // The period inside `red.blue` should be safely ignored and not trigger a sentence boundary.
         let template_mxp = cache
             .get_or_compile("a <COLOR red.blue>fierce {source} [source:approach].")
-            .unwrap();
-        let output_mxp = render_msg!("char_2", &template_mxp, "source" => &goblin).unwrap();
+            .expect("Failed to compile template");
+        let output_mxp = render_msg!("char_2", &template_mxp, "source" => &goblin)
+            .expect("Failed to render template");
         assert_eq!(output_mxp, "A <COLOR red.blue>fierce goblin approaches.");
     }
 
@@ -834,8 +892,9 @@ mod tests {
 
         let template_msp = cache
             .get_or_compile("!!SOUND(roar.wav){the:source} [source:roar].")
-            .unwrap();
-        let output_msp = render_msg!("char_2", &template_msp, "source" => &goblin).unwrap();
+            .expect("Failed to compile template");
+        let output_msp = render_msg!("char_2", &template_msp, "source" => &goblin)
+            .expect("Failed to render template");
         assert_eq!(output_msp, "!!SOUND(roar.wav)The goblin roars.");
     }
 
@@ -856,9 +915,10 @@ mod tests {
             .get_or_compile(
                 "\x1b[1;32m<SEND href=\"look\">{the:source} [source:wave].\x1b[0m <COLOR blue>it [source:smile].",
             )
-            .unwrap();
+            .expect("Failed to compile template");
 
-        let output_mixed = render_msg!("char_2", &template_mixed, "source" => &goblin).unwrap();
+        let output_mixed = render_msg!("char_2", &template_mixed, "source" => &goblin)
+            .expect("Failed to render template");
         assert_eq!(
             output_mixed,
             "\x1b[1;32m<SEND href=\"look\">The goblin waves.\x1b[0m <COLOR blue>It smiles."
@@ -882,9 +942,10 @@ mod tests {
         // the `[` and `{` inside them as verb or entity tags, resulting in a syntax error.
         let template = cache
             .get_or_compile("<SEND HREF=\"[look]\">{the:source} triggers a !!SOUND({roar})!")
-            .unwrap();
+            .expect("Failed to compile template");
 
-        let output = render_msg!("char_2", &template, "source" => &goblin).unwrap();
+        let output = render_msg!("char_2", &template, "source" => &goblin)
+            .expect("Failed to render template");
         assert_eq!(
             output,
             "<SEND HREF=\"[look]\">The goblin triggers a !!SOUND({roar})!"
@@ -908,9 +969,10 @@ mod tests {
         // the `[` and `{` inside the URL as verb or entity tags, resulting in a syntax error.
         let template = cache
             .get_or_compile("\x1b]8;;https://example.com/?q={123}&v=[456]\x07{the:source} [source:attack].\x1b]8;;\x07")
-            .unwrap();
+            .expect("Failed to compile template");
 
-        let output = render_msg!("char_2", &template, "source" => &goblin).unwrap();
+        let output = render_msg!("char_2", &template, "source" => &goblin)
+            .expect("Failed to render template");
         assert_eq!(
             output,
             "\x1b]8;;https://example.com/?q={123}&v=[456]\x07The goblin attacks.\x1b]8;;\x07"
@@ -966,9 +1028,10 @@ mod tests {
         // Falls back to literal text. The {the:source} tag is parsed successfully.
         let template = cache
             .get_or_compile("<color red unterminated {the:source} [source:attack].")
-            .unwrap();
+            .expect("Failed to compile template");
 
-        let output = render_msg!("char_2", &template, "source" => &goblin).unwrap();
+        let output = render_msg!("char_2", &template, "source" => &goblin)
+            .expect("Failed to render template");
         assert_eq!(output, "<Color red unterminated the goblin attacks.");
     }
 
@@ -989,9 +1052,10 @@ mod tests {
         // Falls back to literal text. The {the:source} tag is parsed successfully.
         let template = cache
             .get_or_compile("!!SOUND(roar.wav unterminated {the:source} [source:attack].")
-            .unwrap();
+            .expect("Failed to compile template");
 
-        let output = render_msg!("char_2", &template, "source" => &goblin).unwrap();
+        let output = render_msg!("char_2", &template, "source" => &goblin)
+            .expect("Failed to render template");
         assert_eq!(output, "!!SOUND(roar.wav unterminated the goblin attacks.");
     }
 
@@ -1010,9 +1074,10 @@ mod tests {
         // Verifies that escaped braces, brackets, and backslashes are cleanly bypassed
         let template = cache
             .get_or_compile(r"some \{escaped\} and \[tags\]. \\{The:source}")
-            .unwrap();
+            .expect("Failed to compile template");
 
-        let output = render_msg!("char_2", &template, "source" => &goblin).unwrap();
+        let output = render_msg!("char_2", &template, "source" => &goblin)
+            .expect("Failed to render template");
         assert_eq!(output, r"Some {escaped} and [tags]. \The goblin");
     }
 
@@ -1216,8 +1281,9 @@ mod tests {
         };
         let template_art = cache
             .get_or_compile("{the:source} [source:attack].")
-            .unwrap();
-        let out_art = render_msg!("char_2", &template_art, "source" => &goblin_group).unwrap();
+            .expect("Failed to compile template");
+        let out_art = render_msg!("char_2", &template_art, "source" => &goblin_group)
+            .expect("Failed to render template");
         assert_eq!(out_art, "The goblin attacks.");
     }
 
@@ -1243,31 +1309,34 @@ mod tests {
         // 1. Demonstratives (this -> these) combined with Past Tense "To Be" (was -> were)
         let template = cache
             .get_or_compile("{This:source} [source:be] angry.")
-            .unwrap();
+            .expect("Failed to compile template");
 
         let ctx_singular = RenderContext::new("char_2")
             .with_tense(crate::models::Tense::Past)
             .with_entity("source", &goblin);
-        let out_singular = PerspectiveEngine::render(&template, &ctx_singular).unwrap();
+        let out_singular =
+            PerspectiveEngine::render(&template, &ctx_singular).expect("Failed to render template");
         assert_eq!(out_singular, "This goblin was angry.");
 
         let ctx_plural = RenderContext::new("char_2")
             .with_tense(crate::models::Tense::Past)
             .with_entity("source", &wolves);
-        let out_plural = PerspectiveEngine::render(&template, &ctx_plural).unwrap();
+        let out_plural =
+            PerspectiveEngine::render(&template, &ctx_plural).expect("Failed to render template");
         assert_eq!(out_plural, "These wolves were angry.");
 
         // 2. Automatically suppresses the demonstrative for the viewer just like an article
         let ctx_viewer = RenderContext::new("mob_2")
             .with_tense(crate::models::Tense::Past)
             .with_entity("source", &wolves);
-        let out_viewer = PerspectiveEngine::render(&template, &ctx_viewer).unwrap();
+        let out_viewer =
+            PerspectiveEngine::render(&template, &ctx_viewer).expect("Failed to render template");
         assert_eq!(out_viewer, "You were angry.");
 
         // 3. Forcing an article for a proper noun using the `+` prefix
         let template_force = cache
             .get_or_compile("{+This:source} [source:be] angry.")
-            .unwrap();
+            .expect("Failed to compile template");
         let aldran = MockEntity {
             id: "char_1".to_string(),
             name: "Aldran".to_string(),
@@ -1275,7 +1344,8 @@ mod tests {
             is_plural: false,
             is_proper_noun: true,
         };
-        let out_forced = render_msg!("char_2", &template_force, "source" => &aldran).unwrap();
+        let out_forced = render_msg!("char_2", &template_force, "source" => &aldran)
+            .expect("Failed to render template");
         assert_eq!(out_forced, "This Aldran is angry.");
     }
 
@@ -1323,9 +1393,13 @@ mod tests {
         let ctx = RenderContext::new("viewer");
 
         // [+smile] should output "smiles" (director stance, which is default anyway, but tests parser stripping)
-        let out_director =
-            PerspectiveEngine::render(&cache.get_or_compile("he [+smile].").unwrap(), &ctx)
-                .unwrap();
+        let out_director = PerspectiveEngine::render(
+            &cache
+                .get_or_compile("he [+smile].")
+                .expect("Failed to compile template"),
+            &ctx,
+        )
+        .expect("Failed to render template");
         assert_eq!(out_director, "He smiles.");
     }
 
@@ -1355,20 +1429,20 @@ mod tests {
         // 1. First time using a pronoun tag: Automatically expands to the full name!
         let t1 = cache
             .get_or_compile("{target:Subj} [target:look] around.")
-            .unwrap();
-        let out1 = PerspectiveEngine::render(&t1, &ctx).unwrap();
+            .expect("Failed to compile template");
+        let out1 = PerspectiveEngine::render(&t1, &ctx).expect("Failed to render template");
         assert_eq!(out1, "A goblin looks around.");
 
         // 2. Second time using a pronoun tag: The context REMEMBERS the goblin and uses "It"!
         let t2 = cache
             .get_or_compile("{target:Subj} [target:attack]!")
-            .unwrap();
-        let out2 = PerspectiveEngine::render(&t2, &ctx).unwrap();
+            .expect("Failed to compile template");
+        let out2 = PerspectiveEngine::render(&t2, &ctx).expect("Failed to render template");
         assert_eq!(out2, "It attacks!");
 
         // 3. Clearing the context resets the memory, expanding it to the full name again.
         ctx.clear_anaphora();
-        let out3 = PerspectiveEngine::render(&t2, &ctx).unwrap();
+        let out3 = PerspectiveEngine::render(&t2, &ctx).expect("Failed to render template");
         assert_eq!(out3, "A goblin attacks!");
 
         // 4. Interruption by another entity prevents confusing pronouns
@@ -1377,8 +1451,8 @@ mod tests {
             .get_or_compile(
                 "{The:target} enters. {The:other} blinks. {target:Subj} [target:scream].",
             )
-            .unwrap();
-        let out4 = PerspectiveEngine::render(&t4, &ctx).unwrap();
+            .expect("Failed to compile template");
+        let out4 = PerspectiveEngine::render(&t4, &ctx).expect("Failed to render template");
         // Because the slime (Neutral) was just introduced, the pronoun for the target (goblin, also Neutral)
         // is now ambiguous. The engine must safely expand it back to "The goblin" to prevent confusion.
         assert_eq!(
@@ -1391,9 +1465,9 @@ mod tests {
         ctx.clear_anaphora();
         let t5 = cache
             .get_or_compile("{Other:poss} sword falls, and {other:subj} cuts {other:reflex}.")
-            .unwrap();
+            .expect("Failed to compile template");
 
-        let out5 = PerspectiveEngine::render(&t5, &ctx).unwrap();
+        let out5 = PerspectiveEngine::render(&t5, &ctx).expect("Failed to render template");
         assert_eq!(out5, "A slime's sword falls, and it cuts itself.");
     }
 
@@ -1499,9 +1573,9 @@ mod tests {
             .with_entity("aldran", &aldran);
         let t1 = cache
             .get_or_compile("Bob [bob:attack] {aldran}. {aldran:Subj} [aldran:fall].")
-            .unwrap();
+            .expect("Failed to compile template");
         assert_eq!(
-            PerspectiveEngine::render(&t1, &ctx1).unwrap(),
+            PerspectiveEngine::render(&t1, &ctx1).expect("Failed to render template"),
             "Bob attacks Aldran. Aldran falls."
         );
 
@@ -1512,9 +1586,9 @@ mod tests {
             .with_entity("aldran", &aldran);
         let t2 = cache
             .get_or_compile("Jill [jill:attack] {aldran}. {aldran:Subj} [aldran:fall].")
-            .unwrap();
+            .expect("Failed to compile template");
         assert_eq!(
-            PerspectiveEngine::render(&t2, &ctx2).unwrap(),
+            PerspectiveEngine::render(&t2, &ctx2).expect("Failed to render template"),
             "Jill attacks Aldran. He falls."
         );
     }
@@ -1537,8 +1611,8 @@ mod tests {
         // We expect "A giant spider", NOT "A Giant Spider" or "A Giant spider".
         let template = cache
             .get_or_compile("{target:Subj} [target:hiss].")
-            .unwrap();
-        let output = PerspectiveEngine::render(&template, &ctx).unwrap();
+            .expect("Failed to compile template");
+        let output = PerspectiveEngine::render(&template, &ctx).expect("Failed to render template");
         assert_eq!(output, "A giant spider hisses.");
     }
 
@@ -1553,14 +1627,16 @@ mod tests {
         };
 
         let cache = TemplateCache::new(100);
-        let t1 = cache.get_or_compile("{the:target} enters.").unwrap();
+        let t1 = cache
+            .get_or_compile("{the:target} enters.")
+            .expect("Failed to compile template");
         let t2 = cache
             .get_or_compile("{target:Subj} [target:look] around.")
-            .unwrap();
+            .expect("Failed to compile template");
 
         // Render the first template in context 1
         let ctx1 = RenderContext::new("char_2").with_entity("target", &goblin);
-        let _ = PerspectiveEngine::render(&t1, &ctx1).unwrap();
+        let _ = PerspectiveEngine::render(&t1, &ctx1).expect("Failed to render template");
 
         // Extract the full narrative state from context 1 and inject it into a brand new context 2
         let state = ctx1.extract_anaphora();
@@ -1568,7 +1644,7 @@ mod tests {
             .with_entity("target", &goblin)
             .with_anaphora(state);
 
-        let out2 = PerspectiveEngine::render(&t2, &ctx2).unwrap();
+        let out2 = PerspectiveEngine::render(&t2, &ctx2).expect("Failed to render template");
         // The engine natively uses "It" instead of "The goblin" because the context was seeded!
         assert_eq!(out2, "It looks around.");
     }
@@ -1593,16 +1669,16 @@ mod tests {
         let cache = TemplateCache::new(100);
         let t1 = cache
             .get_or_compile("{bob} is standing next to {aldran}.")
-            .unwrap();
+            .expect("Failed to compile template");
         let t2 = cache
             .get_or_compile("{aldran:Subj} [aldran:wave].")
-            .unwrap();
+            .expect("Failed to compile template");
 
         // Render the first sentence
         let ctx1 = RenderContext::new("viewer")
             .with_entity("aldran", &aldran)
             .with_entity("bob", &bob);
-        let out1 = PerspectiveEngine::render(&t1, &ctx1).unwrap();
+        let out1 = PerspectiveEngine::render(&t1, &ctx1).expect("Failed to render template");
         assert_eq!(out1, "Bob is standing next to Aldran.");
 
         // Carry the state over to context 2
@@ -1614,7 +1690,7 @@ mod tests {
 
         // Because the state includes Bob in the recent_entities memory, the engine knows
         // that Aldran and Bob are both male and prevents the ambiguous "He waves."
-        let out2 = PerspectiveEngine::render(&t2, &ctx2).unwrap();
+        let out2 = PerspectiveEngine::render(&t2, &ctx2).expect("Failed to render template");
         assert_eq!(out2, "Aldran waves.");
     }
 
@@ -1655,26 +1731,28 @@ mod tests {
         let _ = PerspectiveEngine::render(
             &cache
                 .get_or_compile("{aldran} [aldran:wave] at {bob}.")
-                .unwrap(),
+                .expect("Failed to compile template"),
             &ctx,
         )
-        .unwrap();
+        .expect("Failed to render template");
 
         // 2. Introduce the goblin (Memory: Bob, Goblin). Aldran is evicted!
         let _ = PerspectiveEngine::render(
             &cache
                 .get_or_compile("{the:goblin} [goblin:approach].")
-                .unwrap(),
+                .expect("Failed to compile template"),
             &ctx,
         )
-        .unwrap();
+        .expect("Failed to render template");
 
         // 3. Request a pronoun for Bob. He is still in memory, so he is safely remembered as the subject.
         let out_bob = PerspectiveEngine::render(
-            &cache.get_or_compile("{bob:Subj} [bob:smile].").unwrap(),
+            &cache
+                .get_or_compile("{bob:Subj} [bob:smile].")
+                .expect("Failed to compile template"),
             &ctx,
         )
-        .unwrap();
+        .expect("Failed to render template");
         assert_eq!(out_bob, "He smiles.");
 
         // 4. Request a pronoun for Aldran. Because he was evicted, the engine forgot he was Male,
@@ -1682,10 +1760,10 @@ mod tests {
         let out_aldran = PerspectiveEngine::render(
             &cache
                 .get_or_compile("{aldran:Subj} [aldran:sigh].")
-                .unwrap(),
+                .expect("Failed to compile template"),
             &ctx,
         )
-        .unwrap();
+        .expect("Failed to render template");
         assert_eq!(out_aldran, "Aldran sighs.");
     }
 
@@ -1731,20 +1809,37 @@ mod tests {
             .with_entity("dan", &m4)
             .with_pinned_entity("bob"); // Bob is pinned to memory!
 
-        let _ = PerspectiveEngine::render(&cache.get_or_compile("{tom} arrives.").unwrap(), &ctx)
-            .unwrap();
-        let _ = PerspectiveEngine::render(&cache.get_or_compile("{jim} arrives.").unwrap(), &ctx)
-            .unwrap();
-        let _ = PerspectiveEngine::render(&cache.get_or_compile("{dan} arrives.").unwrap(), &ctx)
-            .unwrap();
+        let _ = PerspectiveEngine::render(
+            &cache
+                .get_or_compile("{tom} arrives.")
+                .expect("Failed to compile template"),
+            &ctx,
+        )
+        .expect("Failed to render template");
+        let _ = PerspectiveEngine::render(
+            &cache
+                .get_or_compile("{jim} arrives.")
+                .expect("Failed to compile template"),
+            &ctx,
+        )
+        .expect("Failed to render template");
+        let _ = PerspectiveEngine::render(
+            &cache
+                .get_or_compile("{dan} arrives.")
+                .expect("Failed to compile template"),
+            &ctx,
+        )
+        .expect("Failed to render template");
 
         // Dan was the last mentioned. Bob is NOT the last mentioned, but is pinned in memory.
         // Memory has Dan (Male) and Bob (Male). Both are male. Bob's pronoun "He" is correctly recognized as ambiguous!
         let out_bob = PerspectiveEngine::render(
-            &cache.get_or_compile("{bob:Subj} [bob:smile].").unwrap(),
+            &cache
+                .get_or_compile("{bob:Subj} [bob:smile].")
+                .expect("Failed to compile template"),
             &ctx,
         )
-        .unwrap();
+        .expect("Failed to render template");
         assert_eq!(out_bob, "Bob smiles.");
 
         // Now we explicitly forget Dan. The only male in memory is Bob.
@@ -1752,30 +1847,49 @@ mod tests {
 
         // Now "He" for Bob should be unambiguous!
         let out_bob2 = PerspectiveEngine::render(
-            &cache.get_or_compile("{bob:Subj} [bob:wave].").unwrap(),
+            &cache
+                .get_or_compile("{bob:Subj} [bob:wave].")
+                .expect("Failed to compile template"),
             &ctx,
         )
-        .unwrap();
+        .expect("Failed to render template");
         assert_eq!(out_bob2, "He waves.");
 
         // Now unpin Bob and let him naturally evict.
         ctx.unpin_anaphora("bob");
 
         // Add Tom, Jim, Dan to push Bob out of the LRU cache
-        let _ = PerspectiveEngine::render(&cache.get_or_compile("{tom} arrives.").unwrap(), &ctx)
-            .unwrap();
-        let _ = PerspectiveEngine::render(&cache.get_or_compile("{jim} arrives.").unwrap(), &ctx)
-            .unwrap();
-        let _ = PerspectiveEngine::render(&cache.get_or_compile("{dan} arrives.").unwrap(), &ctx)
-            .unwrap();
+        let _ = PerspectiveEngine::render(
+            &cache
+                .get_or_compile("{tom} arrives.")
+                .expect("Failed to compile template"),
+            &ctx,
+        )
+        .expect("Failed to render template");
+        let _ = PerspectiveEngine::render(
+            &cache
+                .get_or_compile("{jim} arrives.")
+                .expect("Failed to compile template"),
+            &ctx,
+        )
+        .expect("Failed to render template");
+        let _ = PerspectiveEngine::render(
+            &cache
+                .get_or_compile("{dan} arrives.")
+                .expect("Failed to compile template"),
+            &ctx,
+        )
+        .expect("Failed to render template");
 
         // Now memory should be [Jim, Dan]. Bob is gone.
         // Requesting Bob's pronoun will just treat him as a newly introduced entity and print his name.
         let out_bob3 = PerspectiveEngine::render(
-            &cache.get_or_compile("{bob:Subj} [bob:nod].").unwrap(),
+            &cache
+                .get_or_compile("{bob:Subj} [bob:nod].")
+                .expect("Failed to compile template"),
             &ctx,
         )
-        .unwrap();
+        .expect("Failed to render template");
         assert_eq!(out_bob3, "Bob nods.");
     }
 
@@ -1827,8 +1941,13 @@ mod tests {
             is_proper_noun: true,
         };
         let ctx = ctx.with_entity("dan", &m4);
-        let _ = PerspectiveEngine::render(&cache.get_or_compile("{dan} arrives.").unwrap(), &ctx)
-            .unwrap();
+        let _ = PerspectiveEngine::render(
+            &cache
+                .get_or_compile("{dan} arrives.")
+                .expect("Failed to compile template"),
+            &ctx,
+        )
+        .expect("Failed to render template");
 
         // The limit is still 2. The anaphora check sees 4 entities, but 3 are pinned.
         // It will evict Dan immediately because he is the only unpinned entity.
@@ -1870,18 +1989,19 @@ mod tests {
             .get_or_compile(
                 "{Source} [source:hit] {the:target}, then {source:subj} [source:step] back.",
             )
-            .unwrap();
+            .expect("Failed to compile template");
 
         // 1. Bystander (Director Stance)
         // Because "goblin" took focus, "Aldran" cannot safely use "he". It falls back to "Aldran".
         let out_director =
-            render_msg!("char_3", &template, "source" => &player, "target" => &goblin).unwrap();
+            render_msg!("char_3", &template, "source" => &player, "target" => &goblin)
+                .expect("Failed to render template");
         assert_eq!(out_director, "Aldran hits the goblin, then he steps back.");
 
         // 2. Player (Actor Stance)
         // Even though "goblin" took focus, "you" is immune to anaphora ambiguity. It stays "you".
-        let out_actor =
-            render_msg!("char_1", &template, "source" => &player, "target" => &goblin).unwrap();
+        let out_actor = render_msg!("char_1", &template, "source" => &player, "target" => &goblin)
+            .expect("Failed to render template");
         assert_eq!(out_actor, "You hit the goblin, then you step back.");
     }
 
@@ -1932,8 +2052,8 @@ mod tests {
         // Without a subject, verbs safely default to 3rd-person singular conjugation
         let template = cache
             .get_or_compile("a shadow [loom] in the distance, and [approach].")
-            .unwrap();
-        let out = PerspectiveEngine::render(&template, &ctx).unwrap();
+            .expect("Failed to compile template");
+        let out = PerspectiveEngine::render(&template, &ctx).expect("Failed to render template");
         assert_eq!(out, "A shadow looms in the distance, and approaches.");
     }
 
@@ -2055,38 +2175,42 @@ mod tests {
         };
 
         let cache = TemplateCache::new(100);
-        let template = cache.get_or_compile("{Source} [source:draw] {a:source.weapon} and [source:swing] {source:poss} {source.weapon}!").unwrap();
+        let template = cache.get_or_compile("{Source} [source:draw] {a:source.weapon} and [source:swing] {source:poss} {source.weapon}!").expect("Failed to compile template");
 
-        let out_director = render_msg!("char_2", &template, "source" => &player).unwrap();
+        let out_director = render_msg!("char_2", &template, "source" => &player)
+            .expect("Failed to render template");
         assert_eq!(
             out_director,
             "Aldran draws a rusty sword and swings his rusty sword!"
         );
 
-        let out_actor = render_msg!("char_1", &template, "source" => &player).unwrap();
+        let out_actor = render_msg!("char_1", &template, "source" => &player)
+            .expect("Failed to render template");
         assert_eq!(
             out_actor,
             "You draw a rusty sword and swing your rusty sword!"
         );
 
         // Verify graceful error handling if a builder requests a property that doesn't exist
-        let err_template = cache.get_or_compile("{source.shield} breaks.").unwrap();
+        let err_template = cache
+            .get_or_compile("{source.shield} breaks.")
+            .expect("Failed to compile template");
         let err_output = PerspectiveEngine::render(
             &err_template,
             &RenderContext::new("char_1").with_entity("source", &player),
         )
-        .unwrap_err();
+        .expect_err("Expected an error");
         assert_eq!(err_output, "Missing property 'shield' on entity 'source'");
 
         // Verify multi-level error handling tracks the traversed path accurately
         let err_template_multi = cache
             .get_or_compile("{source.weapon.edge} is sharp.")
-            .unwrap();
+            .expect("Failed to compile template");
         let err_output_multi = PerspectiveEngine::render(
             &err_template_multi,
             &RenderContext::new("char_1").with_entity("source", &player),
         )
-        .unwrap_err();
+        .expect_err("Expected an error");
         assert_eq!(
             err_output_multi,
             "Missing property 'edge' on entity 'source.weapon'"
@@ -2095,7 +2219,7 @@ mod tests {
         // Verify malformed double-dot paths return a clear error at compile time
         let double_dot_err = cache
             .get_or_compile("{a:source..weapon} is drawn.")
-            .unwrap_err();
+            .expect_err("Expected an error");
         assert_eq!(
             double_dot_err,
             "Entity tag has an empty property segment: {a:source..weapon}"
@@ -2155,17 +2279,17 @@ mod tests {
         // 1. Success at 3 levels deep (tree -> child -> child -> child)
         let t1 = cache
             .get_or_compile("You look at {the:tree.child.child.child}.")
-            .unwrap();
+            .expect("Failed to compile template");
         assert_eq!(
-            PerspectiveEngine::render(&t1, &ctx).unwrap(),
+            PerspectiveEngine::render(&t1, &ctx).expect("Failed to render template"),
             "You look at the leaf."
         );
 
         // 2. Graceful error tracking at 4 levels deep
         let t_err = cache
             .get_or_compile("You look at {the:tree.child.child.child.bug}.")
-            .unwrap();
-        let err_output = PerspectiveEngine::render(&t_err, &ctx).unwrap_err();
+            .expect("Failed to compile template");
+        let err_output = PerspectiveEngine::render(&t_err, &ctx).expect_err("Expected an error");
         assert_eq!(
             err_output,
             "Missing property 'bug' on entity 'tree.child.child.child'"
@@ -2200,18 +2324,21 @@ mod tests {
         let cache = TemplateCache::new(100);
         let template = cache
             .get_or_compile("You take {the:target's} gold.")
-            .unwrap();
+            .expect("Failed to compile template");
 
         // Singular common noun ending in 's' with ANSI code at the end -> expects 's
-        let out_boss = render_msg!("char_2", &template, "target" => &colored_boss).unwrap();
+        let out_boss = render_msg!("char_2", &template, "target" => &colored_boss)
+            .expect("Failed to render template");
         assert_eq!(out_boss, "You take the \x1b[31mboss\x1b[0m's gold.");
 
         // Plural common noun ending in 's' with ANSI code at the end -> expects '
-        let out_wolves = render_msg!("char_2", &template, "target" => &colored_wolves).unwrap();
+        let out_wolves = render_msg!("char_2", &template, "target" => &colored_wolves)
+            .expect("Failed to render template");
         assert_eq!(out_wolves, "You take the \x1b[32mwolves\x1b[0m' gold.");
 
         // Regular singular common noun with ANSI code at the end -> expects 's
-        let out_goblin = render_msg!("char_2", &template, "target" => &colored_goblin).unwrap();
+        let out_goblin = render_msg!("char_2", &template, "target" => &colored_goblin)
+            .expect("Failed to render template");
         assert_eq!(out_goblin, "You take the \x1b[33mgoblin\x1b[0m's gold.");
     }
 
@@ -2235,14 +2362,16 @@ mod tests {
         let cache = TemplateCache::new(100);
         let template = cache
             .get_or_compile("You take {the:target's} gold.")
-            .unwrap();
+            .expect("Failed to compile template");
 
         // Plural ending in 's' followed by space -> expects '
-        let out_wolves = render_msg!("char_2", &template, "target" => &wolves_spaced).unwrap();
+        let out_wolves = render_msg!("char_2", &template, "target" => &wolves_spaced)
+            .expect("Failed to render template");
         assert_eq!(out_wolves, "You take the wolves ' gold.");
 
         // Singular ending in 's' followed by multiple spaces -> expects 's
-        let out_boss = render_msg!("char_2", &template, "target" => &boss_spaced).unwrap();
+        let out_boss = render_msg!("char_2", &template, "target" => &boss_spaced)
+            .expect("Failed to render template");
         assert_eq!(out_boss, "You take the boss   's gold.");
     }
 
@@ -2259,24 +2388,27 @@ mod tests {
         let cache = TemplateCache::new(100);
         let template = cache
             .get_or_compile("{source} [source:walk] forward.")
-            .unwrap();
+            .expect("Failed to compile template");
 
         // Second Person (Default)
-        let out_second = render_msg!("char_1", &template, "source" => &player).unwrap();
+        let out_second = render_msg!("char_1", &template, "source" => &player)
+            .expect("Failed to render template");
         assert_eq!(out_second, "You walk forward.");
 
         // First Person
         let ctx_first = RenderContext::new("char_1")
             .with_stance(crate::models::ActorStance::FirstPerson)
             .with_entity("source", &player);
-        let out_first = PerspectiveEngine::render(&template, &ctx_first).unwrap();
+        let out_first =
+            PerspectiveEngine::render(&template, &ctx_first).expect("Failed to render template");
         assert_eq!(out_first, "I walk forward.");
 
         // Third Person
         let ctx_third = RenderContext::new("char_1")
             .with_stance(crate::models::ActorStance::ThirdPerson)
             .with_entity("source", &player);
-        let out_third = PerspectiveEngine::render(&template, &ctx_third).unwrap();
+        let out_third =
+            PerspectiveEngine::render(&template, &ctx_third).expect("Failed to render template");
         assert_eq!(out_third, "Aldran walks forward.");
     }
 
@@ -2294,21 +2426,22 @@ mod tests {
 
         let template_be = cache
             .get_or_compile("{source} [source:be] looking for {source:poss} sword.")
-            .unwrap();
+            .expect("Failed to compile template");
         let ctx_first = RenderContext::new("char_1")
             .with_stance(crate::models::ActorStance::FirstPerson)
             .with_entity("source", &player);
         assert_eq!(
-            PerspectiveEngine::render(&template_be, &ctx_first).unwrap(),
+            PerspectiveEngine::render(&template_be, &ctx_first).expect("Failed to render template"),
             "I am looking for my sword."
         );
 
         let template_past = cache
             .get_or_compile("Before, {source} [source:be] looking.")
-            .unwrap();
+            .expect("Failed to compile template");
         let ctx_past = ctx_first.with_tense(crate::models::Tense::Past);
         assert_eq!(
-            PerspectiveEngine::render(&template_past, &ctx_past).unwrap(),
+            PerspectiveEngine::render(&template_past, &ctx_past)
+                .expect("Failed to render template"),
             "Before, I was looking."
         );
     }
@@ -2336,14 +2469,14 @@ mod tests {
         let cache = TemplateCache::new(100);
         let template = cache
             .get_or_compile("{source} [source:open] the door.")
-            .unwrap();
+            .expect("Failed to compile template");
 
         // First Person
         let ctx_first = RenderContext::new("char_1")
             .with_stance(crate::models::ActorStance::FirstPerson)
             .with_entity("source", &party);
         assert_eq!(
-            PerspectiveEngine::render(&template, &ctx_first).unwrap(),
+            PerspectiveEngine::render(&template, &ctx_first).expect("Failed to render template"),
             "Bob and I open the door."
         );
 
@@ -2352,7 +2485,7 @@ mod tests {
             .with_stance(crate::models::ActorStance::ThirdPerson)
             .with_entity("source", &party);
         assert_eq!(
-            PerspectiveEngine::render(&template, &ctx_third).unwrap(),
+            PerspectiveEngine::render(&template, &ctx_third).expect("Failed to render template"),
             "Aldran and Bob open the door."
         );
     }
@@ -2379,7 +2512,7 @@ mod tests {
             .get_or_compile(
                 "{source} [source:hit] {the:target}. {target:Subj} [target:hit] {source:obj} back.",
             )
-            .unwrap();
+            .expect("Failed to compile template");
 
         // First Person
         let ctx_first = RenderContext::new("char_1")
@@ -2387,7 +2520,7 @@ mod tests {
             .with_entity("source", &player)
             .with_entity("target", &goblin);
         assert_eq!(
-            PerspectiveEngine::render(&template, &ctx_first).unwrap(),
+            PerspectiveEngine::render(&template, &ctx_first).expect("Failed to render template"),
             "I hit the goblin. It hits me back."
         );
 
@@ -2397,7 +2530,7 @@ mod tests {
             .with_entity("source", &player)
             .with_entity("target", &goblin);
         assert_eq!(
-            PerspectiveEngine::render(&template, &ctx_third).unwrap(),
+            PerspectiveEngine::render(&template, &ctx_third).expect("Failed to render template"),
             "Aldran hits the goblin. It hits him back."
         );
     }
@@ -2415,7 +2548,7 @@ mod tests {
         let cache = TemplateCache::new(100);
         let template = cache
             .get_or_compile("{+source} [+source:draw] {+source:poss} sword.")
-            .unwrap();
+            .expect("Failed to compile template");
 
         let ctx_first = RenderContext::new("char_1")
             .with_stance(crate::models::ActorStance::FirstPerson)
@@ -2423,7 +2556,7 @@ mod tests {
 
         // The '+' prefix should safely override the First Person 'I/my' back to 'Aldran/his'
         assert_eq!(
-            PerspectiveEngine::render(&template, &ctx_first).unwrap(),
+            PerspectiveEngine::render(&template, &ctx_first).expect("Failed to render template"),
             "Aldran draws his sword."
         );
     }
@@ -2459,7 +2592,7 @@ mod tests {
         let cache = TemplateCache::new(100);
         let template = cache
             .get_or_compile("{source:Subj} [source:defend] {source:reflex}. {The:target} [target:strike] {source:obj}. It is {source:poss} fight, the victory is {source:abs_poss}!")
-            .unwrap();
+            .expect("Failed to compile template");
 
         // 1. First Person Singular
         let ctx_first = RenderContext::new("char_1")
@@ -2467,7 +2600,7 @@ mod tests {
             .with_entity("source", &player)
             .with_entity("target", &goblin);
         assert_eq!(
-            PerspectiveEngine::render(&template, &ctx_first).unwrap(),
+            PerspectiveEngine::render(&template, &ctx_first).expect("Failed to render template"),
             "I defend myself. The goblin strikes me. It is my fight, the victory is mine!"
         );
 
@@ -2477,7 +2610,8 @@ mod tests {
             .with_entity("source", &party)
             .with_entity("target", &goblin);
         assert_eq!(
-            PerspectiveEngine::render(&template, &ctx_first_plural).unwrap(),
+            PerspectiveEngine::render(&template, &ctx_first_plural)
+                .expect("Failed to render template"),
             "We defend ourselves. The goblin strikes us. It is our fight, the victory is ours!"
         );
 
@@ -2487,7 +2621,7 @@ mod tests {
             .with_entity("source", &player)
             .with_entity("target", &goblin);
         assert_eq!(
-            PerspectiveEngine::render(&template, &ctx_second).unwrap(),
+            PerspectiveEngine::render(&template, &ctx_second).expect("Failed to render template"),
             "You defend yourself. The goblin strikes you. It is your fight, the victory is yours!"
         );
 
@@ -2499,7 +2633,7 @@ mod tests {
             .with_entity("target", &goblin)
             .with_last_mentioned("source");
         assert_eq!(
-            PerspectiveEngine::render(&template, &ctx_third).unwrap(),
+            PerspectiveEngine::render(&template, &ctx_third).expect("Failed to render template"),
             "He defends himself. The goblin strikes him. It is his fight, the victory is his!"
         );
     }
@@ -2516,13 +2650,15 @@ mod tests {
 
         let cache = TemplateCache::new(100);
         // Tests whether `{source's}` evaluates to "my", "your", or "Aldran's"
-        let template = cache.get_or_compile("They take {source's} gold.").unwrap();
+        let template = cache
+            .get_or_compile("They take {source's} gold.")
+            .expect("Failed to compile template");
 
         let ctx_first = RenderContext::new("char_1")
             .with_stance(crate::models::ActorStance::FirstPerson)
             .with_entity("source", &player);
         assert_eq!(
-            PerspectiveEngine::render(&template, &ctx_first).unwrap(),
+            PerspectiveEngine::render(&template, &ctx_first).expect("Failed to render template"),
             "They take my gold."
         );
 
@@ -2530,7 +2666,7 @@ mod tests {
             .with_stance(crate::models::ActorStance::SecondPerson)
             .with_entity("source", &player);
         assert_eq!(
-            PerspectiveEngine::render(&template, &ctx_second).unwrap(),
+            PerspectiveEngine::render(&template, &ctx_second).expect("Failed to render template"),
             "They take your gold."
         );
 
@@ -2538,7 +2674,7 @@ mod tests {
             .with_stance(crate::models::ActorStance::ThirdPerson)
             .with_entity("source", &player);
         assert_eq!(
-            PerspectiveEngine::render(&template, &ctx_third).unwrap(),
+            PerspectiveEngine::render(&template, &ctx_third).expect("Failed to render template"),
             "They take Aldran's gold."
         );
     }
@@ -2563,7 +2699,7 @@ mod tests {
         let cache = TemplateCache::new(100);
         let template = cache
             .get_or_compile("{source} [source:attack] {the:target} with {source:poss} claws!")
-            .unwrap();
+            .expect("Failed to compile template");
 
         let ctx = RenderContext::new("mob_1")
             .with_stance(crate::models::ActorStance::FirstPerson)
@@ -2571,7 +2707,7 @@ mod tests {
             .with_entity("target", &goblin);
 
         assert_eq!(
-            PerspectiveEngine::render(&template, &ctx).unwrap(),
+            PerspectiveEngine::render(&template, &ctx).expect("Failed to render template"),
             "We attack the goblin with our claws!"
         );
 
@@ -2582,20 +2718,21 @@ mod tests {
 
         let group_template = cache
             .get_or_compile("{the:source} [source:attack]!")
-            .unwrap();
+            .expect("Failed to compile template");
         let group_ctx = RenderContext::new("mob_1")
             .with_stance(crate::models::ActorStance::FirstPerson)
             .with_entity("source", &party);
 
         assert_eq!(
-            PerspectiveEngine::render(&group_template, &group_ctx).unwrap(),
+            PerspectiveEngine::render(&group_template, &group_ctx)
+                .expect("Failed to render template"),
             "You, the goblin, and I attack!"
         );
 
         // Objective pronouns
         let obj_template = cache
             .get_or_compile("{the:target} [target:ambush] {source:obj}!")
-            .unwrap();
+            .expect("Failed to compile template");
 
         // 1. Solo plural viewer
         let obj_ctx_solo = RenderContext::new("mob_1")
@@ -2604,7 +2741,8 @@ mod tests {
             .with_entity("target", &goblin);
 
         assert_eq!(
-            PerspectiveEngine::render(&obj_template, &obj_ctx_solo).unwrap(),
+            PerspectiveEngine::render(&obj_template, &obj_ctx_solo)
+                .expect("Failed to render template"),
             "The goblin ambushes us!"
         );
 
@@ -2616,7 +2754,8 @@ mod tests {
 
         // A pronoun referring to a group that includes a 1st-person viewer correctly collapses to "us"
         assert_eq!(
-            PerspectiveEngine::render(&obj_template, &obj_ctx_group).unwrap(),
+            PerspectiveEngine::render(&obj_template, &obj_ctx_group)
+                .expect("Failed to render template"),
             "The goblin ambushes us!"
         );
     }
@@ -2672,12 +2811,12 @@ mod tests {
 
         let template = cache
             .get_or_compile("You take {the:source's} gold.")
-            .unwrap();
+            .expect("Failed to compile template");
 
         // 1. Second Person Mixed -> "your and the goblin's"
         let ctx_second = RenderContext::new("char_1").with_entity("source", &mixed_party);
         assert_eq!(
-            PerspectiveEngine::render(&template, &ctx_second).unwrap(),
+            PerspectiveEngine::render(&template, &ctx_second).expect("Failed to render template"),
             "You take your and the goblin's gold."
         );
 
@@ -2686,14 +2825,15 @@ mod tests {
             .with_stance(crate::models::ActorStance::FirstPerson)
             .with_entity("source", &mixed_party);
         assert_eq!(
-            PerspectiveEngine::render(&template, &ctx_first).unwrap(),
+            PerspectiveEngine::render(&template, &ctx_first).expect("Failed to render template"),
             "You take the goblin's and my gold."
         );
 
         // 3. Second Person Solo -> "your"
         let ctx_solo_second = RenderContext::new("char_1").with_entity("source", &solo_party);
         assert_eq!(
-            PerspectiveEngine::render(&template, &ctx_solo_second).unwrap(),
+            PerspectiveEngine::render(&template, &ctx_solo_second)
+                .expect("Failed to render template"),
             "You take your gold."
         );
 
@@ -2702,14 +2842,15 @@ mod tests {
             .with_stance(crate::models::ActorStance::FirstPerson)
             .with_entity("source", &solo_party);
         assert_eq!(
-            PerspectiveEngine::render(&template, &ctx_solo_first).unwrap(),
+            PerspectiveEngine::render(&template, &ctx_solo_first)
+                .expect("Failed to render template"),
             "You take my gold."
         );
 
         // 5. Third Person Mixed -> "Aldran and the goblin's"
         let ctx_third = RenderContext::new("char_2").with_entity("source", &mixed_party);
         assert_eq!(
-            PerspectiveEngine::render(&template, &ctx_third).unwrap(),
+            PerspectiveEngine::render(&template, &ctx_third).expect("Failed to render template"),
             "You take Aldran and the goblin's gold."
         );
 
@@ -2718,14 +2859,16 @@ mod tests {
             .with_stance(crate::models::ActorStance::FirstPerson)
             .with_entity("source", &big_mixed_party);
         assert_eq!(
-            PerspectiveEngine::render(&template, &ctx_first_big).unwrap(),
+            PerspectiveEngine::render(&template, &ctx_first_big)
+                .expect("Failed to render template"),
             "You take the goblin's, the slime's, and my gold."
         );
 
         // 7. Second Person Big Mixed -> "your, the goblin's, and the slime's"
         let ctx_second_big = RenderContext::new("char_1").with_entity("source", &big_mixed_party);
         assert_eq!(
-            PerspectiveEngine::render(&template, &ctx_second_big).unwrap(),
+            PerspectiveEngine::render(&template, &ctx_second_big)
+                .expect("Failed to render template"),
             "You take your, the goblin's, and the slime's gold."
         );
 
@@ -2734,7 +2877,8 @@ mod tests {
             .with_stance(crate::models::ActorStance::FirstPerson)
             .with_entity("source", &solo_wolves_party);
         assert_eq!(
-            PerspectiveEngine::render(&template, &ctx_first_plural_solo).unwrap(),
+            PerspectiveEngine::render(&template, &ctx_first_plural_solo)
+                .expect("Failed to render template"),
             "You take our gold."
         );
 
@@ -2743,7 +2887,8 @@ mod tests {
             .with_stance(crate::models::ActorStance::FirstPerson)
             .with_entity("source", &mixed_wolves_party);
         assert_eq!(
-            PerspectiveEngine::render(&template, &ctx_first_plural_mixed).unwrap(),
+            PerspectiveEngine::render(&template, &ctx_first_plural_mixed)
+                .expect("Failed to render template"),
             "You take your, the goblin's, and my gold."
         );
     }
@@ -2791,13 +2936,13 @@ mod tests {
         // 1. Unambiguous Group Pronoun
         let t1 = cache
             .get_or_compile("{the:goblin} [goblin:ambush] {party}. {party:Subj} [party:retaliate]!")
-            .unwrap();
+            .expect("Failed to compile template");
         let ctx1 = RenderContext::new("char_3")
             .with_entity("party", &party)
             .with_entity("goblin", &goblin);
 
         assert_eq!(
-            PerspectiveEngine::render(&t1, &ctx1).unwrap(),
+            PerspectiveEngine::render(&t1, &ctx1).expect("Failed to render template"),
             "The goblin ambushes Aldran and Bob. They retaliate!"
         );
 
@@ -2806,14 +2951,14 @@ mod tests {
             .get_or_compile(
                 "{the:monsters} [monsters:ambush] {party}. {party:Subj} [party:retaliate]!",
             )
-            .unwrap();
+            .expect("Failed to compile template");
         let ctx2 = RenderContext::new("char_3")
             .with_entity("party", &party)
             .with_entity("monsters", &monsters);
 
         // The anaphora ambiguity check should safely catch the collision and fall back to the group's name.
         assert_eq!(
-            PerspectiveEngine::render(&t2, &ctx2).unwrap(),
+            PerspectiveEngine::render(&t2, &ctx2).expect("Failed to render template"),
             "The goblin and the slime ambush Aldran and Bob. Aldran and Bob retaliate!"
         );
 
@@ -2824,7 +2969,7 @@ mod tests {
             .with_entity("monsters", &monsters);
 
         assert_eq!(
-            PerspectiveEngine::render(&t2, &ctx3).unwrap(),
+            PerspectiveEngine::render(&t2, &ctx3).expect("Failed to render template"),
             "The goblin and the slime ambush you and Bob. You retaliate!"
         );
 
@@ -2835,7 +2980,7 @@ mod tests {
             .with_entity("monsters", &monsters);
 
         assert_eq!(
-            PerspectiveEngine::render(&t2, &ctx4).unwrap(),
+            PerspectiveEngine::render(&t2, &ctx4).expect("Failed to render template"),
             "The goblin and the slime ambush Bob and I. We retaliate!"
         );
     }
@@ -2883,44 +3028,44 @@ mod tests {
         // 1. Nested Solo -> Acts as Singular Male
         let t1 = cache
             .get_or_compile("{the:target} [target:nod]. {target:Subj} [target:smile].")
-            .unwrap();
+            .expect("Failed to compile template");
         let ctx1 = RenderContext::new("viewer").with_entity("target", &nested_solo);
         assert_eq!(
-            PerspectiveEngine::render(&t1, &ctx1).unwrap(),
+            PerspectiveEngine::render(&t1, &ctx1).expect("Failed to render template"),
             "Aldran nods. He smiles."
         );
 
         // 2. Ambiguity with Nested Solo (Male) and Bob (Male)
         let t2 = cache
             .get_or_compile("{bob} [bob:look] at {target}. {target:Subj} [target:smile].")
-            .unwrap();
+            .expect("Failed to compile template");
         let ctx2 = RenderContext::new("viewer")
             .with_entity("bob", &bob)
             .with_entity("target", &nested_solo);
         assert_eq!(
-            PerspectiveEngine::render(&t2, &ctx2).unwrap(),
+            PerspectiveEngine::render(&t2, &ctx2).expect("Failed to render template"),
             "Bob looks at Aldran. Aldran smiles."
         );
 
         // 3. Nested Plural -> Acts as Plural
         let t3 = cache
             .get_or_compile("{the:party} [party:nod]. {party:Subj} [party:smile].")
-            .unwrap();
+            .expect("Failed to compile template");
         let ctx3 = RenderContext::new("viewer").with_entity("party", &nested_plural);
         assert_eq!(
-            PerspectiveEngine::render(&t3, &ctx3).unwrap(),
+            PerspectiveEngine::render(&t3, &ctx3).expect("Failed to render template"),
             "Aldran and Bob nod. They smile."
         );
 
         // 4. Ambiguity with Nested Plural (Plural) and Wolves (Plural)
         let t4 = cache
             .get_or_compile("{the:wolves} [wolves:look] at {party}. {party:Subj} [party:smile].")
-            .unwrap();
+            .expect("Failed to compile template");
         let ctx4 = RenderContext::new("viewer")
             .with_entity("wolves", &wolves)
             .with_entity("party", &nested_plural);
         assert_eq!(
-            PerspectiveEngine::render(&t4, &ctx4).unwrap(),
+            PerspectiveEngine::render(&t4, &ctx4).expect("Failed to render template"),
             "The wolves look at Aldran and Bob. Aldran and Bob smile."
         );
     }
@@ -2945,24 +3090,29 @@ mod tests {
 
         // 2. Inject into a new context and verify behavior
         let cache = TemplateCache::new(100);
-        let template = cache.get_or_compile("{source:Subj} [source:nod].").unwrap();
+        let template = cache
+            .get_or_compile("{source:Subj} [source:nod].")
+            .expect("Failed to compile template");
 
         let ctx_injected = RenderContext::new("viewer")
             .with_entity("source", &player)
             .with_anaphora(empty_state);
 
         // Because the state is completely empty, it should safely fall back to the full name instead of using a pronoun.
-        let out = PerspectiveEngine::render(&template, &ctx_injected).unwrap();
+        let out =
+            PerspectiveEngine::render(&template, &ctx_injected).expect("Failed to render template");
         assert_eq!(out, "Aldran nods.");
     }
 
     #[test]
     fn test_empty_template_string() {
         let cache = TemplateCache::new(100);
-        let template = cache.get_or_compile("").unwrap();
+        let template = cache
+            .get_or_compile("")
+            .expect("Failed to compile template");
 
         let ctx = RenderContext::new("viewer");
-        let output = PerspectiveEngine::render(&template, &ctx).unwrap();
+        let output = PerspectiveEngine::render(&template, &ctx).expect("Failed to render template");
 
         assert_eq!(output, "");
     }
@@ -2994,8 +3144,13 @@ mod tests {
             .with_last_mentioned("bob"); // Triggers the LRU refresh path
 
         // Render Tom to force an eviction check (Memory is now [Bob, Tom])
-        let _ = PerspectiveEngine::render(&cache.get_or_compile("{tom} arrives.").unwrap(), &ctx)
-            .unwrap();
+        let _ = PerspectiveEngine::render(
+            &cache
+                .get_or_compile("{tom} arrives.")
+                .expect("Failed to compile template"),
+            &ctx,
+        )
+        .expect("Failed to render template");
 
         // If `with_last_mentioned` accidentally cleared Bob's flags, he would have been evicted as the oldest.
         // Because his IS_PINNED flag was preserved, Tom (the newest but unpinned) is instantly evicted instead!
@@ -3034,8 +3189,13 @@ mod tests {
             .with_anaphora(state);
 
         // Render Tom to force an eviction check. Memory becomes [Bob, Tom] and then limits are enforced.
-        let _ = PerspectiveEngine::render(&cache.get_or_compile("{tom} arrives.").unwrap(), &ctx2)
-            .unwrap();
+        let _ = PerspectiveEngine::render(
+            &cache
+                .get_or_compile("{tom} arrives.")
+                .expect("Failed to compile template"),
+            &ctx2,
+        )
+        .expect("Failed to render template");
 
         // Because the state extraction/injection preserved Bob's IS_PINNED flag, Tom is evicted instead.
         assert_eq!(ctx2.recent_entities.borrow().len(), 1);
@@ -3055,51 +3215,68 @@ mod tests {
         let cache = TemplateCache::new(100);
 
         // 1. "fly" -> "flies"
-        let template_fly = cache.get_or_compile("{source} [source:fly].").unwrap();
+        let template_fly = cache
+            .get_or_compile("{source} [source:fly].")
+            .expect("Failed to compile template");
         assert_eq!(
-            render_msg!("char_1", &template_fly, "source" => &player).unwrap(),
+            render_msg!("char_1", &template_fly, "source" => &player)
+                .expect("Failed to render template"),
             "You fly."
         );
         assert_eq!(
-            render_msg!("char_2", &template_fly, "source" => &player).unwrap(),
+            render_msg!("char_2", &template_fly, "source" => &player)
+                .expect("Failed to render template"),
             "Aldran flies."
         );
 
         // 2. "run" -> "ran" (Dynamic past tense shift)
-        let template_run = cache.get_or_compile("{source} [source:run].").unwrap();
+        let template_run = cache
+            .get_or_compile("{source} [source:run].")
+            .expect("Failed to compile template");
         let ctx_actor_past = RenderContext::new("char_1")
             .with_tense(crate::models::Tense::Past)
             .with_entity("source", &player);
         assert_eq!(
-            PerspectiveEngine::render(&template_run, &ctx_actor_past).unwrap(),
+            PerspectiveEngine::render(&template_run, &ctx_actor_past)
+                .expect("Failed to render template"),
             "You ran."
         );
         let ctx_director_past = RenderContext::new("char_2")
             .with_tense(crate::models::Tense::Past)
             .with_entity("source", &player);
         assert_eq!(
-            PerspectiveEngine::render(&template_run, &ctx_director_past).unwrap(),
+            PerspectiveEngine::render(&template_run, &ctx_director_past)
+                .expect("Failed to render template"),
             "Aldran ran."
         );
 
         // 3. "catch" -> "catches"
-        let template_catch = cache.get_or_compile("{source} [source:catch] it.").unwrap();
+        let template_catch = cache
+            .get_or_compile("{source} [source:catch] it.")
+            .expect("Failed to compile template");
         assert_eq!(
-            render_msg!("char_2", &template_catch, "source" => &player).unwrap(),
+            render_msg!("char_2", &template_catch, "source" => &player)
+                .expect("Failed to render template"),
             "Aldran catches it."
         );
 
         // 4. Fallback rule: consonant + y -> ies ("try" -> "tries")
-        let template_try = cache.get_or_compile("{source} [source:try].").unwrap();
+        let template_try = cache
+            .get_or_compile("{source} [source:try].")
+            .expect("Failed to compile template");
         assert_eq!(
-            render_msg!("char_2", &template_try, "source" => &player).unwrap(),
+            render_msg!("char_2", &template_try, "source" => &player)
+                .expect("Failed to render template"),
             "Aldran tries."
         );
 
         // 5. Fallback rule: ends with x -> es ("box" -> "boxes")
-        let template_box = cache.get_or_compile("{source} [source:box].").unwrap();
+        let template_box = cache
+            .get_or_compile("{source} [source:box].")
+            .expect("Failed to compile template");
         assert_eq!(
-            render_msg!("char_2", &template_box, "source" => &player).unwrap(),
+            render_msg!("char_2", &template_box, "source" => &player)
+                .expect("Failed to render template"),
             "Aldran boxes."
         );
 
@@ -3110,13 +3287,17 @@ mod tests {
         ];
         for modal in modals {
             let template_str = format!("{{source}} [source:{modal}].");
-            let template_modal = cache.get_or_compile(&template_str).unwrap();
+            let template_modal = cache
+                .get_or_compile(&template_str)
+                .expect("Failed to compile template");
             assert_eq!(
-                render_msg!("char_1", &template_modal, "source" => &player).unwrap(),
+                render_msg!("char_1", &template_modal, "source" => &player)
+                    .expect("Failed to render template"),
                 format!("You {modal}.")
             );
             assert_eq!(
-                render_msg!("char_2", &template_modal, "source" => &player).unwrap(),
+                render_msg!("char_2", &template_modal, "source" => &player)
+                    .expect("Failed to render template"),
                 format!("Aldran {modal}.")
             );
         }
@@ -3165,15 +3346,18 @@ mod tests {
         let ctx_third_past = ctx_third.with_tense(crate::models::Tense::Past);
 
         assert_eq!(
-            PerspectiveEngine::render(&template_be, &ctx_first_past).unwrap(),
+            PerspectiveEngine::render(&template_be, &ctx_first_past)
+                .expect("Failed to render template"),
             "I was ready."
         );
         assert_eq!(
-            PerspectiveEngine::render(&template_be, &ctx_second_past).unwrap(),
+            PerspectiveEngine::render(&template_be, &ctx_second_past)
+                .expect("Failed to render template"),
             "You were ready."
         );
         assert_eq!(
-            PerspectiveEngine::render(&template_be, &ctx_third_past).unwrap(),
+            PerspectiveEngine::render(&template_be, &ctx_third_past)
+                .expect("Failed to render template"),
             "Aldran was ready."
         );
 
@@ -3182,21 +3366,30 @@ mod tests {
             .with_stance(crate::models::ActorStance::FirstPerson)
             .with_entity("source", &player);
 
-        let template_fly = cache.get_or_compile("{source} [source:fly].").unwrap();
+        let template_fly = cache
+            .get_or_compile("{source} [source:fly].")
+            .expect("Failed to compile template");
         assert_eq!(
-            PerspectiveEngine::render(&template_fly, &ctx_first).unwrap(),
+            PerspectiveEngine::render(&template_fly, &ctx_first)
+                .expect("Failed to render template"),
             "I fly."
         );
 
-        let template_catch = cache.get_or_compile("{source} [source:catch] it.").unwrap();
+        let template_catch = cache
+            .get_or_compile("{source} [source:catch] it.")
+            .expect("Failed to compile template");
         assert_eq!(
-            PerspectiveEngine::render(&template_catch, &ctx_first).unwrap(),
+            PerspectiveEngine::render(&template_catch, &ctx_first)
+                .expect("Failed to render template"),
             "I catch it."
         );
 
-        let template_try = cache.get_or_compile("{source} [source:try].").unwrap();
+        let template_try = cache
+            .get_or_compile("{source} [source:try].")
+            .expect("Failed to compile template");
         assert_eq!(
-            PerspectiveEngine::render(&template_try, &ctx_first).unwrap(),
+            PerspectiveEngine::render(&template_try, &ctx_first)
+                .expect("Failed to render template"),
             "I try."
         );
     }
@@ -3225,17 +3418,20 @@ mod tests {
 
         let template_have = cache
             .get_or_compile("{source} [source:have] a sword.")
-            .unwrap();
+            .expect("Failed to compile template");
         assert_eq!(
-            PerspectiveEngine::render(&template_have, &ctx_first).unwrap(),
+            PerspectiveEngine::render(&template_have, &ctx_first)
+                .expect("Failed to render template"),
             "I have a sword."
         );
         assert_eq!(
-            PerspectiveEngine::render(&template_have, &ctx_second).unwrap(),
+            PerspectiveEngine::render(&template_have, &ctx_second)
+                .expect("Failed to render template"),
             "You have a sword."
         );
         assert_eq!(
-            PerspectiveEngine::render(&template_have, &ctx_third).unwrap(),
+            PerspectiveEngine::render(&template_have, &ctx_third)
+                .expect("Failed to render template"),
             "Aldran has a sword."
         );
 
@@ -3244,15 +3440,18 @@ mod tests {
         let ctx_third_past = ctx_third.with_tense(crate::models::Tense::Past);
 
         assert_eq!(
-            PerspectiveEngine::render(&template_have, &ctx_first_past).unwrap(),
+            PerspectiveEngine::render(&template_have, &ctx_first_past)
+                .expect("Failed to render template"),
             "I had a sword."
         );
         assert_eq!(
-            PerspectiveEngine::render(&template_have, &ctx_second_past).unwrap(),
+            PerspectiveEngine::render(&template_have, &ctx_second_past)
+                .expect("Failed to render template"),
             "You had a sword."
         );
         assert_eq!(
-            PerspectiveEngine::render(&template_have, &ctx_third_past).unwrap(),
+            PerspectiveEngine::render(&template_have, &ctx_third_past)
+                .expect("Failed to render template"),
             "Aldran had a sword."
         );
     }
@@ -3271,11 +3470,15 @@ mod tests {
         let cache = TemplateCache::new(100);
 
         // Add a completely new custom verb
-        crate::grammar::add_irregular_verb("yeet", "yeetses", "yeeted").unwrap();
+        crate::grammar::add_irregular_verb("yeet", "yeetses", "yeeted")
+            .expect("Failed to add custom verb");
 
-        let template = cache.get_or_compile("{source} [source:yeet].").unwrap();
+        let template = cache
+            .get_or_compile("{source} [source:yeet].")
+            .expect("Failed to compile template");
         assert_eq!(
-            render_msg!("char_2", &template, "source" => &player).unwrap(),
+            render_msg!("char_2", &template, "source" => &player)
+                .expect("Failed to render template"),
             "Aldran yeetses."
         );
 
@@ -3285,9 +3488,12 @@ mod tests {
         // Forcing an existing PHF verb should succeed and override
         crate::grammar::force_add_irregular_verb("arise", "arizez", "arouze");
 
-        let template_arise = cache.get_or_compile("{source} [source:arise].").unwrap();
+        let template_arise = cache
+            .get_or_compile("{source} [source:arise].")
+            .expect("Failed to compile template");
         assert_eq!(
-            render_msg!("char_2", &template_arise, "source" => &player).unwrap(),
+            render_msg!("char_2", &template_arise, "source" => &player)
+                .expect("Failed to render template"),
             "Aldran arizez."
         );
 
@@ -3319,23 +3525,27 @@ mod tests {
             .with_entity("source", &player)
             .with_tense(crate::models::Tense::Past);
 
-        let t1 = cache.get_or_compile("{source} [source:bloop].").unwrap();
+        let t1 = cache
+            .get_or_compile("{source} [source:bloop].")
+            .expect("Failed to compile template");
         assert_eq!(
-            PerspectiveEngine::render(&t1, &ctx_pres).unwrap(),
+            PerspectiveEngine::render(&t1, &ctx_pres).expect("Failed to render template"),
             "Aldran bloopses."
         );
         assert_eq!(
-            PerspectiveEngine::render(&t1, &ctx_past).unwrap(),
+            PerspectiveEngine::render(&t1, &ctx_past).expect("Failed to render template"),
             "Aldran bloopeded."
         );
 
-        let t2 = cache.get_or_compile("{source} [source:blarg].").unwrap();
+        let t2 = cache
+            .get_or_compile("{source} [source:blarg].")
+            .expect("Failed to compile template");
         assert_eq!(
-            PerspectiveEngine::render(&t2, &ctx_pres).unwrap(),
+            PerspectiveEngine::render(&t2, &ctx_pres).expect("Failed to render template"),
             "Aldran blargs."
         );
         assert_eq!(
-            PerspectiveEngine::render(&t2, &ctx_past).unwrap(),
+            PerspectiveEngine::render(&t2, &ctx_past).expect("Failed to render template"),
             "Aldran blarged."
         );
 
@@ -3358,20 +3568,25 @@ mod tests {
         // 1. Force a pirate conjugation
         let template_pirate = cache
             .get_or_compile("{source} [source:be|be] looking tired.")
-            .unwrap();
+            .expect("Failed to compile template");
         assert_eq!(
-            render_msg!("char_1", &template_pirate, "source" => &player).unwrap(),
+            render_msg!("char_1", &template_pirate, "source" => &player)
+                .expect("Failed to render template"),
             "You be looking tired."
         );
         assert_eq!(
-            render_msg!("char_2", &template_pirate, "source" => &player).unwrap(),
+            render_msg!("char_2", &template_pirate, "source" => &player)
+                .expect("Failed to render template"),
             "Aldran be looking tired."
         );
 
         // 2. Force capitalization correctly
-        let template_cap = cache.get_or_compile("[source:Look|gaze] at me!").unwrap();
+        let template_cap = cache
+            .get_or_compile("[source:Look|gaze] at me!")
+            .expect("Failed to compile template");
         assert_eq!(
-            render_msg!("char_2", &template_cap, "source" => &player).unwrap(),
+            render_msg!("char_2", &template_cap, "source" => &player)
+                .expect("Failed to render template"),
             "Gaze at me!"
         );
     }
@@ -3393,19 +3608,22 @@ mod tests {
 
         let template = cache
             .get_or_compile("{source} [source:pick up] the sword.")
-            .unwrap();
+            .expect("Failed to compile template");
         assert_eq!(
-            PerspectiveEngine::render(&template, &ctx_second).unwrap(),
+            PerspectiveEngine::render(&template, &ctx_second).expect("Failed to render template"),
             "You pick up the sword."
         );
         assert_eq!(
-            PerspectiveEngine::render(&template, &ctx_third).unwrap(),
+            PerspectiveEngine::render(&template, &ctx_third).expect("Failed to render template"),
             "Aldran picks up the sword."
         );
 
-        let template_cap = cache.get_or_compile("[source:Give up]!").unwrap();
+        let template_cap = cache
+            .get_or_compile("[source:Give up]!")
+            .expect("Failed to compile template");
         assert_eq!(
-            PerspectiveEngine::render(&template_cap, &ctx_third).unwrap(),
+            PerspectiveEngine::render(&template_cap, &ctx_third)
+                .expect("Failed to render template"),
             "Gives up!"
         );
     }
@@ -3426,35 +3644,38 @@ mod tests {
         // 1. Phrasal verb naturally split ("look around" -> "looks around")
         let t1 = cache
             .get_or_compile("{source} [source:look around].")
-            .unwrap();
+            .expect("Failed to compile template");
         assert_eq!(
-            PerspectiveEngine::render(&t1, &ctx).unwrap(),
+            PerspectiveEngine::render(&t1, &ctx).expect("Failed to render template"),
             "Aldran looks around."
         );
 
         // 2. Phrasal verb explicitly in PHF ("pinch run" -> "pinch runs")
         let t2 = cache
             .get_or_compile("{source} [source:pinch run].")
-            .unwrap();
+            .expect("Failed to compile template");
         assert_eq!(
-            PerspectiveEngine::render(&t2, &ctx).unwrap(),
+            PerspectiveEngine::render(&t2, &ctx).expect("Failed to render template"),
             "Aldran pinch runs."
         );
 
         // 3. Hyphenated verb treated as single word ("cross-pollinate" -> "cross-pollinates")
         let t3 = cache
             .get_or_compile("{source} [source:cross-pollinate].")
-            .unwrap();
+            .expect("Failed to compile template");
         assert_eq!(
-            PerspectiveEngine::render(&t3, &ctx).unwrap(),
+            PerspectiveEngine::render(&t3, &ctx).expect("Failed to render template"),
             "Aldran cross-pollinates."
         );
 
         // 4. Runtime dictionary multi-word override ("make do" -> "makes do")
-        crate::grammar::add_irregular_verb("make do", "makes do", "made do").unwrap();
-        let t4 = cache.get_or_compile("{source} [source:make do].").unwrap();
+        crate::grammar::add_irregular_verb("make do", "makes do", "made do")
+            .expect("Failed to add custom verb");
+        let t4 = cache
+            .get_or_compile("{source} [source:make do].")
+            .expect("Failed to compile template");
         assert_eq!(
-            PerspectiveEngine::render(&t4, &ctx).unwrap(),
+            PerspectiveEngine::render(&t4, &ctx).expect("Failed to render template"),
             "Aldran makes do."
         );
 
@@ -3482,14 +3703,14 @@ mod tests {
         let cache = TemplateCache::new(100);
         let template = cache
             .get_or_compile("{source} [source:hit] {the:target} and [source:laugh].")
-            .unwrap();
+            .expect("Failed to compile template");
 
         let ctx_present = RenderContext::new("char_1")
             .with_entity("source", &player)
             .with_entity("target", &goblin);
 
         assert_eq!(
-            PerspectiveEngine::render(&template, &ctx_present).unwrap(),
+            PerspectiveEngine::render(&template, &ctx_present).expect("Failed to render template"),
             "You hit the goblin and laugh."
         );
 
@@ -3499,7 +3720,7 @@ mod tests {
             .with_tense(crate::models::Tense::Past);
 
         assert_eq!(
-            PerspectiveEngine::render(&template, &ctx_past).unwrap(),
+            PerspectiveEngine::render(&template, &ctx_past).expect("Failed to render template"),
             "You hit the goblin and laughed."
         );
 
@@ -3509,7 +3730,8 @@ mod tests {
             .with_tense(crate::models::Tense::Past);
 
         assert_eq!(
-            PerspectiveEngine::render(&template, &ctx_past_director).unwrap(),
+            PerspectiveEngine::render(&template, &ctx_past_director)
+                .expect("Failed to render template"),
             "Aldran hit the goblin and laughed."
         );
     }
@@ -3537,7 +3759,7 @@ mod tests {
         let cache = TemplateCache::new(100);
         let template = cache
             .get_or_compile("{the:source} [source:be] here, and [source:try] to escape.")
-            .unwrap();
+            .expect("Failed to compile template");
 
         let ctx_solo_actor = RenderContext::new("char_1")
             .with_stance(crate::models::ActorStance::FirstPerson)
@@ -3545,7 +3767,8 @@ mod tests {
             .with_entity("source", &player);
 
         assert_eq!(
-            PerspectiveEngine::render(&template, &ctx_solo_actor).unwrap(),
+            PerspectiveEngine::render(&template, &ctx_solo_actor)
+                .expect("Failed to render template"),
             "I was here, and tried to escape."
         );
 
@@ -3554,7 +3777,8 @@ mod tests {
             .with_entity("source", &goblin);
 
         assert_eq!(
-            PerspectiveEngine::render(&template, &ctx_solo_director).unwrap(),
+            PerspectiveEngine::render(&template, &ctx_solo_director)
+                .expect("Failed to render template"),
             "The goblin was here, and tried to escape."
         );
 
@@ -3564,7 +3788,8 @@ mod tests {
             .with_entity("source", &party);
 
         assert_eq!(
-            PerspectiveEngine::render(&template, &ctx_party_actor).unwrap(),
+            PerspectiveEngine::render(&template, &ctx_party_actor)
+                .expect("Failed to render template"),
             "The goblin and I were here, and tried to escape."
         );
     }
@@ -3591,13 +3816,15 @@ mod tests {
 
         for (verb, expected_past) in test_cases {
             let template_str = format!("{{source}} [source:{verb}].");
-            let template = cache.get_or_compile(&template_str).unwrap();
+            let template = cache
+                .get_or_compile(&template_str)
+                .expect("Failed to compile template");
             let ctx = RenderContext::new("char_2")
                 .with_tense(crate::models::Tense::Past)
                 .with_entity("source", &player);
 
             assert_eq!(
-                PerspectiveEngine::render(&template, &ctx).unwrap(),
+                PerspectiveEngine::render(&template, &ctx).expect("Failed to render template"),
                 format!("Aldran {expected_past}.")
             );
         }
@@ -3615,13 +3842,15 @@ mod tests {
 
         let cache = TemplateCache::new(100);
 
-        let template = cache.get_or_compile("{source} [source:catch up].").unwrap();
+        let template = cache
+            .get_or_compile("{source} [source:catch up].")
+            .expect("Failed to compile template");
         let ctx = RenderContext::new("char_2")
             .with_tense(crate::models::Tense::Past)
             .with_entity("source", &player);
 
         assert_eq!(
-            PerspectiveEngine::render(&template, &ctx).unwrap(),
+            PerspectiveEngine::render(&template, &ctx).expect("Failed to render template"),
             "Aldran caught up."
         );
     }
@@ -3646,21 +3875,23 @@ mod tests {
         // 1. Present-only override (falls back to native algorithmic conjugation for past)
         let t_pres_only = cache
             .get_or_compile("{source} [source:freak out|freak out|freaks out].")
-            .unwrap();
+            .expect("Failed to compile template");
 
         assert_eq!(
-            PerspectiveEngine::render(&t_pres_only, &ctx_director_present).unwrap(),
+            PerspectiveEngine::render(&t_pres_only, &ctx_director_present)
+                .expect("Failed to render template"),
             "Aldran freaks out."
         );
         assert_eq!(
-            PerspectiveEngine::render(&t_pres_only, &ctx_director_past).unwrap(),
+            PerspectiveEngine::render(&t_pres_only, &ctx_director_past)
+                .expect("Failed to render template"),
             "Aldran freaked out."
         );
 
         // 2. Both present and past overrides
         let t_both = cache
             .get_or_compile("{source} [source:be|am|are|is;was|were|was] here.")
-            .unwrap();
+            .expect("Failed to compile template");
 
         let ctx_actor_first_present = RenderContext::new("char_1")
             .with_entity("source", &player)
@@ -3671,32 +3902,38 @@ mod tests {
             .with_tense(crate::models::Tense::Past);
 
         assert_eq!(
-            PerspectiveEngine::render(&t_both, &ctx_actor_first_present).unwrap(),
+            PerspectiveEngine::render(&t_both, &ctx_actor_first_present)
+                .expect("Failed to render template"),
             "I am here."
         );
         assert_eq!(
-            PerspectiveEngine::render(&t_both, &ctx_actor_first_past).unwrap(),
+            PerspectiveEngine::render(&t_both, &ctx_actor_first_past)
+                .expect("Failed to render template"),
             "I was here."
         );
         assert_eq!(
-            PerspectiveEngine::render(&t_both, &ctx_director_present).unwrap(),
+            PerspectiveEngine::render(&t_both, &ctx_director_present)
+                .expect("Failed to render template"),
             "Aldran is here."
         );
         assert_eq!(
-            PerspectiveEngine::render(&t_both, &ctx_director_past).unwrap(),
+            PerspectiveEngine::render(&t_both, &ctx_director_past)
+                .expect("Failed to render template"),
             "Aldran was here."
         );
 
         // 3. Past-only override (falls back to native algorithmic conjugation for present)
         let t_past_only = cache
             .get_or_compile("{source} [source:bloop|;blorped].")
-            .unwrap();
+            .expect("Failed to compile template");
         assert_eq!(
-            PerspectiveEngine::render(&t_past_only, &ctx_director_present).unwrap(),
+            PerspectiveEngine::render(&t_past_only, &ctx_director_present)
+                .expect("Failed to render template"),
             "Aldran bloops."
         );
         assert_eq!(
-            PerspectiveEngine::render(&t_past_only, &ctx_director_past).unwrap(),
+            PerspectiveEngine::render(&t_past_only, &ctx_director_past)
+                .expect("Failed to render template"),
             "Aldran blorped."
         );
     }
@@ -3715,11 +3952,11 @@ mod tests {
         // Tests combining dynamically shifted verbs with possessive pronouns, absolute possessives, and reflexive pronouns.
         let template = cache
             .get_or_compile("{source} [source:draw] {source:poss} sword to defend {source:reflex}. The victory [source:be] {source:abs_poss}!")
-            .unwrap();
+            .expect("Failed to compile template");
 
         let ctx_present = RenderContext::new("char_2").with_entity("source", &player);
         assert_eq!(
-            PerspectiveEngine::render(&template, &ctx_present).unwrap(),
+            PerspectiveEngine::render(&template, &ctx_present).expect("Failed to render template"),
             "Aldran draws his sword to defend himself. The victory is his!"
         );
 
@@ -3729,7 +3966,7 @@ mod tests {
 
         // Pronouns should not be affected by tense, but all verbs ("draw" -> "drew", "be" -> "was") should shift.
         assert_eq!(
-            PerspectiveEngine::render(&template, &ctx_past).unwrap(),
+            PerspectiveEngine::render(&template, &ctx_past).expect("Failed to render template"),
             "Aldran drew his sword to defend himself. The victory was his!"
         );
     }
@@ -3747,11 +3984,11 @@ mod tests {
         let cache = TemplateCache::new(100);
         let template = cache
             .get_or_compile("{source} [source:have] no choice, {source:subj} [source:be] trapped.")
-            .unwrap();
+            .expect("Failed to compile template");
 
         let ctx_present = RenderContext::new("char_2").with_entity("source", &player);
         assert_eq!(
-            PerspectiveEngine::render(&template, &ctx_present).unwrap(),
+            PerspectiveEngine::render(&template, &ctx_present).expect("Failed to render template"),
             "Aldran has no choice, he is trapped."
         );
 
@@ -3759,7 +3996,7 @@ mod tests {
             .with_tense(crate::models::Tense::Past)
             .with_entity("source", &player);
         assert_eq!(
-            PerspectiveEngine::render(&template, &ctx_past).unwrap(),
+            PerspectiveEngine::render(&template, &ctx_past).expect("Failed to render template"),
             "Aldran had no choice, he was trapped."
         );
     }
@@ -3784,7 +4021,7 @@ mod tests {
         let cache = TemplateCache::new(100);
         let template = cache
             .get_or_compile("{the:source} [source:strike] {target}. {target:Subj} [target:fall].")
-            .unwrap();
+            .expect("Failed to compile template");
 
         let ctx_past = RenderContext::new("char_3")
             .with_tense(crate::models::Tense::Past)
@@ -3792,7 +4029,7 @@ mod tests {
             .with_entity("target", &player);
 
         assert_eq!(
-            PerspectiveEngine::render(&template, &ctx_past).unwrap(),
+            PerspectiveEngine::render(&template, &ctx_past).expect("Failed to render template"),
             "The goblin struck Aldran. He fell."
         );
     }
@@ -3812,11 +4049,11 @@ mod tests {
         // 1. lie -> lay (e.g. resting)
         let t_lay = cache
             .get_or_compile("{source} [source:lie(lay)] down.")
-            .unwrap();
+            .expect("Failed to compile template");
         // 2. lie -> lied (e.g. deceiving)
         let t_lied = cache
             .get_or_compile("{source} [source:lie(lied)] to me.")
-            .unwrap();
+            .expect("Failed to compile template");
 
         let ctx_pres = RenderContext::new("char_2").with_entity("source", &player);
         let ctx_past = RenderContext::new("char_2")
@@ -3825,21 +4062,21 @@ mod tests {
 
         // In the present tense, both flawlessly evaluate to "lies"
         assert_eq!(
-            PerspectiveEngine::render(&t_lay, &ctx_pres).unwrap(),
+            PerspectiveEngine::render(&t_lay, &ctx_pres).expect("Failed to render template"),
             "Aldran lies down."
         );
         assert_eq!(
-            PerspectiveEngine::render(&t_lied, &ctx_pres).unwrap(),
+            PerspectiveEngine::render(&t_lied, &ctx_pres).expect("Failed to render template"),
             "Aldran lies to me."
         );
 
         // In the past tense, they diverge to their intended meanings!
         assert_eq!(
-            PerspectiveEngine::render(&t_lay, &ctx_past).unwrap(),
+            PerspectiveEngine::render(&t_lay, &ctx_past).expect("Failed to render template"),
             "Aldran lay down."
         );
         assert_eq!(
-            PerspectiveEngine::render(&t_lied, &ctx_past).unwrap(),
+            PerspectiveEngine::render(&t_lied, &ctx_past).expect("Failed to render template"),
             "Aldran lied to me."
         );
     }
@@ -3857,13 +4094,21 @@ mod tests {
         let cache = TemplateCache::new(100);
 
         // 1. Regular Verb
-        let t_walk = cache.get_or_compile("[source:Walk] away.").unwrap();
+        let t_walk = cache
+            .get_or_compile("[source:Walk] away.")
+            .expect("Failed to compile template");
         // 2. Irregular Verb
-        let t_run = cache.get_or_compile("[source:Run] away.").unwrap();
+        let t_run = cache
+            .get_or_compile("[source:Run] away.")
+            .expect("Failed to compile template");
         // 3. Phrasal Verb
-        let t_pick = cache.get_or_compile("[source:Pick up] the sword.").unwrap();
+        let t_pick = cache
+            .get_or_compile("[source:Pick up] the sword.")
+            .expect("Failed to compile template");
         // 4. "To Be"
-        let t_be = cache.get_or_compile("[source:Be] ready.").unwrap();
+        let t_be = cache
+            .get_or_compile("[source:Be] ready.")
+            .expect("Failed to compile template");
 
         let ctx = RenderContext::new("char_2")
             .with_entity("source", &player)
@@ -3871,19 +4116,19 @@ mod tests {
 
         // All of these should retain their first-letter capitalization despite dynamic shifting!
         assert_eq!(
-            PerspectiveEngine::render(&t_walk, &ctx).unwrap(),
+            PerspectiveEngine::render(&t_walk, &ctx).expect("Failed to render template"),
             "Walked away."
         );
         assert_eq!(
-            PerspectiveEngine::render(&t_run, &ctx).unwrap(),
+            PerspectiveEngine::render(&t_run, &ctx).expect("Failed to render template"),
             "Ran away."
         );
         assert_eq!(
-            PerspectiveEngine::render(&t_pick, &ctx).unwrap(),
+            PerspectiveEngine::render(&t_pick, &ctx).expect("Failed to render template"),
             "Picked up the sword."
         );
         assert_eq!(
-            PerspectiveEngine::render(&t_be, &ctx).unwrap(),
+            PerspectiveEngine::render(&t_be, &ctx).expect("Failed to render template"),
             "Was ready."
         );
     }
@@ -3904,27 +4149,33 @@ mod tests {
             .with_tense(crate::models::Tense::Past);
 
         // Modal verbs naturally shift to past tense
-        let t_can = cache.get_or_compile("{source} [source:can] win.").unwrap();
-        let t_will = cache.get_or_compile("{source} [source:will] win.").unwrap();
+        let t_can = cache
+            .get_or_compile("{source} [source:can] win.")
+            .expect("Failed to compile template");
+        let t_will = cache
+            .get_or_compile("{source} [source:will] win.")
+            .expect("Failed to compile template");
         let t_shall = cache
             .get_or_compile("{source} [source:shall] win.")
-            .unwrap();
-        let t_may = cache.get_or_compile("{source} [source:may] win.").unwrap();
+            .expect("Failed to compile template");
+        let t_may = cache
+            .get_or_compile("{source} [source:may] win.")
+            .expect("Failed to compile template");
 
         assert_eq!(
-            PerspectiveEngine::render(&t_can, &ctx).unwrap(),
+            PerspectiveEngine::render(&t_can, &ctx).expect("Failed to render template"),
             "Aldran could win."
         );
         assert_eq!(
-            PerspectiveEngine::render(&t_will, &ctx).unwrap(),
+            PerspectiveEngine::render(&t_will, &ctx).expect("Failed to render template"),
             "Aldran would win."
         );
         assert_eq!(
-            PerspectiveEngine::render(&t_shall, &ctx).unwrap(),
+            PerspectiveEngine::render(&t_shall, &ctx).expect("Failed to render template"),
             "Aldran should win."
         );
         assert_eq!(
-            PerspectiveEngine::render(&t_may, &ctx).unwrap(),
+            PerspectiveEngine::render(&t_may, &ctx).expect("Failed to render template"),
             "Aldran might win."
         );
     }
@@ -3945,65 +4196,73 @@ mod tests {
             .with_tense(crate::models::Tense::Future);
 
         // 1. Regular verb
-        let t_walk = cache.get_or_compile("{source} [source:walk].").unwrap();
+        let t_walk = cache
+            .get_or_compile("{source} [source:walk].")
+            .expect("Failed to compile template");
         assert_eq!(
-            PerspectiveEngine::render(&t_walk, &ctx).unwrap(),
+            PerspectiveEngine::render(&t_walk, &ctx).expect("Failed to render template"),
             "Aldran will walk."
         );
 
         // 2. Irregular verb
-        let t_be = cache.get_or_compile("{source} [source:be] ready.").unwrap();
+        let t_be = cache
+            .get_or_compile("{source} [source:be] ready.")
+            .expect("Failed to compile template");
         assert_eq!(
-            PerspectiveEngine::render(&t_be, &ctx).unwrap(),
+            PerspectiveEngine::render(&t_be, &ctx).expect("Failed to render template"),
             "Aldran will be ready."
         );
 
         // 3. Phrasal verb
         let t_pick = cache
             .get_or_compile("{source} [source:pick up] the sword.")
-            .unwrap();
+            .expect("Failed to compile template");
         assert_eq!(
-            PerspectiveEngine::render(&t_pick, &ctx).unwrap(),
+            PerspectiveEngine::render(&t_pick, &ctx).expect("Failed to render template"),
             "Aldran will pick up the sword."
         );
 
         // 4. Modal verbs (should remain unchanged, preventing "will can")
-        let t_can = cache.get_or_compile("{source} [source:can] win.").unwrap();
+        let t_can = cache
+            .get_or_compile("{source} [source:can] win.")
+            .expect("Failed to compile template");
         assert_eq!(
-            PerspectiveEngine::render(&t_can, &ctx).unwrap(),
+            PerspectiveEngine::render(&t_can, &ctx).expect("Failed to render template"),
             "Aldran can win."
         );
 
         // 5. Capitalization preservation
-        let t_cap = cache.get_or_compile("[source:Attack]!").unwrap();
+        let t_cap = cache
+            .get_or_compile("[source:Attack]!")
+            .expect("Failed to compile template");
         assert_eq!(
-            PerspectiveEngine::render(&t_cap, &ctx).unwrap(),
+            PerspectiveEngine::render(&t_cap, &ctx).expect("Failed to render template"),
             "Will attack!"
         );
 
         // 6. Forced conjugation ignored natively
         let t_forced = cache
             .get_or_compile("{source} [source:freak out|freak out|freaks out]!")
-            .unwrap();
+            .expect("Failed to compile template");
         assert_eq!(
-            PerspectiveEngine::render(&t_forced, &ctx).unwrap(),
+            PerspectiveEngine::render(&t_forced, &ctx).expect("Failed to render template"),
             "Aldran will freak out!"
         );
 
         // 7. Phrasal modal and quasi-modal edge cases
         let t_have_to = cache
             .get_or_compile("{source} [source:have to] win.")
-            .unwrap();
+            .expect("Failed to compile template");
         assert_eq!(
-            PerspectiveEngine::render(&t_have_to, &ctx).unwrap(),
+            PerspectiveEngine::render(&t_have_to, &ctx).expect("Failed to render template"),
             "Aldran will have to win."
         );
 
         let t_ought_to = cache
             .get_or_compile("{source} [source:ought to] win.")
-            .unwrap();
+            .expect("Failed to compile template");
         assert_eq!(
-            PerspectiveEngine::render(&t_ought_to, &ctx).unwrap(),
+            PerspectiveEngine::render(&t_ought_to, &ctx).expect("Failed to render template"),
             "Aldran ought to win."
         );
     }
@@ -4022,7 +4281,7 @@ mod tests {
         // Tests combining dynamically shifted future verbs with possessive pronouns, absolute possessives, and reflexive pronouns.
         let template = cache
             .get_or_compile("{source} [source:draw] {source:poss} sword to defend {source:reflex}. The victory [source:be] {source:abs_poss}!")
-            .unwrap();
+            .expect("Failed to compile template");
 
         let ctx_future = RenderContext::new("char_2")
             .with_tense(crate::models::Tense::Future)
@@ -4030,7 +4289,7 @@ mod tests {
 
         // Pronouns should not be affected by tense, but all verbs ("draw" -> "will draw", "be" -> "will be") should shift.
         assert_eq!(
-            PerspectiveEngine::render(&template, &ctx_future).unwrap(),
+            PerspectiveEngine::render(&template, &ctx_future).expect("Failed to render template"),
             "Aldran will draw his sword to defend himself. The victory will be his!"
         );
     }
@@ -4055,7 +4314,7 @@ mod tests {
         let cache = TemplateCache::new(100);
         let template = cache
             .get_or_compile("{the:source} [source:strike] {target}. {target:Subj} [target:fall].")
-            .unwrap();
+            .expect("Failed to compile template");
 
         let ctx_future = RenderContext::new("char_3")
             .with_tense(crate::models::Tense::Future)
@@ -4063,7 +4322,7 @@ mod tests {
             .with_entity("target", &player);
 
         assert_eq!(
-            PerspectiveEngine::render(&template, &ctx_future).unwrap(),
+            PerspectiveEngine::render(&template, &ctx_future).expect("Failed to render template"),
             "The goblin will strike Aldran. He will fall."
         );
     }
@@ -4091,7 +4350,7 @@ mod tests {
         let cache = TemplateCache::new(100);
         let template = cache
             .get_or_compile("{the:source} [source:be] here, and [source:try] to escape.")
-            .unwrap();
+            .expect("Failed to compile template");
 
         let ctx_party_actor = RenderContext::new("char_1")
             .with_stance(crate::models::ActorStance::FirstPerson)
@@ -4099,7 +4358,8 @@ mod tests {
             .with_entity("source", &party);
 
         assert_eq!(
-            PerspectiveEngine::render(&template, &ctx_party_actor).unwrap(),
+            PerspectiveEngine::render(&template, &ctx_party_actor)
+                .expect("Failed to render template"),
             "The goblin and I will be here, and will try to escape."
         );
     }
@@ -4117,7 +4377,7 @@ mod tests {
         let cache = TemplateCache::new(100);
         let template = cache
             .get_or_compile("{+source} [+source:win] the battle.")
-            .unwrap();
+            .expect("Failed to compile template");
 
         let ctx_future = RenderContext::new("char_1") // Player is the viewer
             .with_tense(crate::models::Tense::Future)
@@ -4125,7 +4385,7 @@ mod tests {
 
         // Even though the viewer is the actor, the `+` syntax forces third person logic
         assert_eq!(
-            PerspectiveEngine::render(&template, &ctx_future).unwrap(),
+            PerspectiveEngine::render(&template, &ctx_future).expect("Failed to render template"),
             "Aldran will win the battle."
         );
     }
@@ -4142,16 +4402,18 @@ mod tests {
 
         let cache = TemplateCache::new(100);
 
-        let t_simple = cache.get_or_compile("{source} [source:walk].").unwrap();
+        let t_simple = cache
+            .get_or_compile("{source} [source:walk].")
+            .expect("Failed to compile template");
         let t_continuous = cache
             .get_or_compile("{source} [source:be] walking.")
-            .unwrap();
+            .expect("Failed to compile template");
         let t_perfect = cache
             .get_or_compile("{source} [source:have] walked.")
-            .unwrap();
+            .expect("Failed to compile template");
         let t_perfect_continuous = cache
             .get_or_compile("{source} [source:have] been walking.")
-            .unwrap();
+            .expect("Failed to compile template");
 
         let ctx_pres = RenderContext::new("char_2").with_entity("source", &player);
         let ctx_past = RenderContext::new("char_2")
@@ -4163,57 +4425,61 @@ mod tests {
 
         // 1. Simple Tenses
         assert_eq!(
-            PerspectiveEngine::render(&t_simple, &ctx_pres).unwrap(),
+            PerspectiveEngine::render(&t_simple, &ctx_pres).expect("Failed to render template"),
             "Aldran walks."
         );
         assert_eq!(
-            PerspectiveEngine::render(&t_simple, &ctx_past).unwrap(),
+            PerspectiveEngine::render(&t_simple, &ctx_past).expect("Failed to render template"),
             "Aldran walked."
         );
         assert_eq!(
-            PerspectiveEngine::render(&t_simple, &ctx_future).unwrap(),
+            PerspectiveEngine::render(&t_simple, &ctx_future).expect("Failed to render template"),
             "Aldran will walk."
         );
 
         // 2. Continuous Tenses
         assert_eq!(
-            PerspectiveEngine::render(&t_continuous, &ctx_pres).unwrap(),
+            PerspectiveEngine::render(&t_continuous, &ctx_pres).expect("Failed to render template"),
             "Aldran is walking."
         );
         assert_eq!(
-            PerspectiveEngine::render(&t_continuous, &ctx_past).unwrap(),
+            PerspectiveEngine::render(&t_continuous, &ctx_past).expect("Failed to render template"),
             "Aldran was walking."
         );
         assert_eq!(
-            PerspectiveEngine::render(&t_continuous, &ctx_future).unwrap(),
+            PerspectiveEngine::render(&t_continuous, &ctx_future)
+                .expect("Failed to render template"),
             "Aldran will be walking."
         );
 
         // 3. Perfect Tenses
         assert_eq!(
-            PerspectiveEngine::render(&t_perfect, &ctx_pres).unwrap(),
+            PerspectiveEngine::render(&t_perfect, &ctx_pres).expect("Failed to render template"),
             "Aldran has walked."
         );
         assert_eq!(
-            PerspectiveEngine::render(&t_perfect, &ctx_past).unwrap(),
+            PerspectiveEngine::render(&t_perfect, &ctx_past).expect("Failed to render template"),
             "Aldran had walked."
         );
         assert_eq!(
-            PerspectiveEngine::render(&t_perfect, &ctx_future).unwrap(),
+            PerspectiveEngine::render(&t_perfect, &ctx_future).expect("Failed to render template"),
             "Aldran will have walked."
         );
 
         // 4. Perfect Continuous Tenses
         assert_eq!(
-            PerspectiveEngine::render(&t_perfect_continuous, &ctx_pres).unwrap(),
+            PerspectiveEngine::render(&t_perfect_continuous, &ctx_pres)
+                .expect("Failed to render template"),
             "Aldran has been walking."
         );
         assert_eq!(
-            PerspectiveEngine::render(&t_perfect_continuous, &ctx_past).unwrap(),
+            PerspectiveEngine::render(&t_perfect_continuous, &ctx_past)
+                .expect("Failed to render template"),
             "Aldran had been walking."
         );
         assert_eq!(
-            PerspectiveEngine::render(&t_perfect_continuous, &ctx_future).unwrap(),
+            PerspectiveEngine::render(&t_perfect_continuous, &ctx_future)
+                .expect("Failed to render template"),
             "Aldran will have been walking."
         );
     }
@@ -4241,54 +4507,54 @@ mod tests {
         // 1. Negative Sentence
         let t_neg = cache
             .get_or_compile("{source} [source:do(aux)] not run.")
-            .unwrap();
+            .expect("Failed to compile template");
 
         assert_eq!(
-            PerspectiveEngine::render(&t_neg, &ctx_pres).unwrap(),
+            PerspectiveEngine::render(&t_neg, &ctx_pres).expect("Failed to render template"),
             "Aldran does not run."
         );
         assert_eq!(
-            PerspectiveEngine::render(&t_neg, &ctx_past).unwrap(),
+            PerspectiveEngine::render(&t_neg, &ctx_past).expect("Failed to render template"),
             "Aldran did not run."
         );
         assert_eq!(
-            PerspectiveEngine::render(&t_neg, &ctx_future).unwrap(),
+            PerspectiveEngine::render(&t_neg, &ctx_future).expect("Failed to render template"),
             "Aldran will not run."
         );
 
         // 2. Question Sentence (Capitalized)
         let t_question = cache
             .get_or_compile("[source:Do(aux)] {source:subj} run?")
-            .unwrap();
+            .expect("Failed to compile template");
 
         assert_eq!(
-            PerspectiveEngine::render(&t_question, &ctx_pres).unwrap(),
+            PerspectiveEngine::render(&t_question, &ctx_pres).expect("Failed to render template"),
             "Does he run?"
         );
         assert_eq!(
-            PerspectiveEngine::render(&t_question, &ctx_past).unwrap(),
+            PerspectiveEngine::render(&t_question, &ctx_past).expect("Failed to render template"),
             "Did he run?"
         );
         assert_eq!(
-            PerspectiveEngine::render(&t_question, &ctx_future).unwrap(),
+            PerspectiveEngine::render(&t_question, &ctx_future).expect("Failed to render template"),
             "Will he run?"
         );
 
         // 3. Main Verb (Unannotated "do")
         let t_main = cache
             .get_or_compile("{source} [source:do] the laundry.")
-            .unwrap();
+            .expect("Failed to compile template");
 
         assert_eq!(
-            PerspectiveEngine::render(&t_main, &ctx_pres).unwrap(),
+            PerspectiveEngine::render(&t_main, &ctx_pres).expect("Failed to render template"),
             "Aldran does the laundry."
         );
         assert_eq!(
-            PerspectiveEngine::render(&t_main, &ctx_past).unwrap(),
+            PerspectiveEngine::render(&t_main, &ctx_past).expect("Failed to render template"),
             "Aldran did the laundry."
         );
         assert_eq!(
-            PerspectiveEngine::render(&t_main, &ctx_future).unwrap(),
+            PerspectiveEngine::render(&t_main, &ctx_future).expect("Failed to render template"),
             "Aldran will do the laundry."
         );
     }
@@ -4306,13 +4572,13 @@ mod tests {
         let cache = TemplateCache::new(100);
         let template = cache
             .get_or_compile("{A:source} [source:walk] in. {A:source} [source:howl].")
-            .unwrap();
+            .expect("Failed to compile template");
 
         let ctx = RenderContext::new("char_1").with_entity("source", &wolf1);
 
         // First mention uses "A", second uses "The"
         assert_eq!(
-            PerspectiveEngine::render(&template, &ctx).unwrap(),
+            PerspectiveEngine::render(&template, &ctx).expect("Failed to render template"),
             "A wolf walks in. The wolf howls."
         );
     }
@@ -4339,7 +4605,7 @@ mod tests {
             .get_or_compile(
                 "{A:source} [source:walk] in. {A:other} [other:walk] in. {A:source} [source:howl].",
             )
-            .unwrap();
+            .expect("Failed to compile template");
 
         let ctx = RenderContext::new("char_1")
             .with_entity("source", &wolf1)
@@ -4347,7 +4613,7 @@ mod tests {
 
         // First is "A", second is "Another", third is "The first"
         assert_eq!(
-            PerspectiveEngine::render(&template, &ctx).unwrap(),
+            PerspectiveEngine::render(&template, &ctx).expect("Failed to render template"),
             "A wolf walks in. Another wolf walks in. The first wolf howls."
         );
     }
@@ -4365,13 +4631,13 @@ mod tests {
         let cache = TemplateCache::new(100);
         let template = cache
             .get_or_compile("{A:source} [source:approach]. {A:source} [source:howl].")
-            .unwrap();
+            .expect("Failed to compile template");
 
         let ctx = RenderContext::new("char_1").with_entity("source", &wolves);
 
         // First is "Some wolves", second is "The wolves"
         assert_eq!(
-            PerspectiveEngine::render(&template, &ctx).unwrap(),
+            PerspectiveEngine::render(&template, &ctx).expect("Failed to render template"),
             "Some wolves approach. The wolves howl."
         );
     }
@@ -4398,24 +4664,24 @@ mod tests {
         // 1. Suppress article upgrade
         let t_article = cache
             .get_or_compile("{A:source} [source:walk] in. {!A:source} [source:howl].")
-            .unwrap();
+            .expect("Failed to compile template");
         let ctx1 = RenderContext::new("char_1").with_entity("source", &wolf1);
         assert_eq!(
-            PerspectiveEngine::render(&t_article, &ctx1).unwrap(),
+            PerspectiveEngine::render(&t_article, &ctx1).expect("Failed to render template"),
             "A wolf walks in. A wolf howls." // The ! prefix successfully suppressed "The"
         );
 
         // 2. Suppress pronoun fallback (Ambiguity between wolf1 and wolf2)
         let t_pronoun = cache
             .get_or_compile("{A:source} [source:walk] in. {A:other} [other:walk] in. {source:!Subj} [source:howl].")
-            .unwrap();
+            .expect("Failed to compile template");
         let ctx2 = RenderContext::new("char_1")
             .with_entity("source", &wolf1)
             .with_entity("other", &wolf2);
 
         // Because of `!`, the engine forces "It howls." instead of falling back to "The wolf howls."
         assert_eq!(
-            PerspectiveEngine::render(&t_pronoun, &ctx2).unwrap(),
+            PerspectiveEngine::render(&t_pronoun, &ctx2).expect("Failed to render template"),
             "A wolf walks in. Another wolf walks in. It howls."
         );
     }
@@ -4434,12 +4700,12 @@ mod tests {
         // Introduces with 'A', uses pronoun, then attempts 'A' again to see if it upgraded to 'The'
         let template = cache
             .get_or_compile("{A:source} [source:arrive]. {source:Subj} [source:wait]. {A:source} [source:attack]!")
-            .unwrap();
+            .expect("Failed to compile template");
 
         let ctx = RenderContext::new("char_1").with_entity("source", &goblin);
 
         assert_eq!(
-            PerspectiveEngine::render(&template, &ctx).unwrap(),
+            PerspectiveEngine::render(&template, &ctx).expect("Failed to render template"),
             "A goblin arrives. It waits. The goblin attacks!"
         );
     }
@@ -4457,12 +4723,12 @@ mod tests {
         let cache = TemplateCache::new(100);
         let template = cache
             .get_or_compile("{A:source's} sword [source:fall]. {A:source's} shield [source:break].")
-            .unwrap();
+            .expect("Failed to compile template");
 
         let ctx = RenderContext::new("char_1").with_entity("source", &goblin);
 
         assert_eq!(
-            PerspectiveEngine::render(&template, &ctx).unwrap(),
+            PerspectiveEngine::render(&template, &ctx).expect("Failed to render template"),
             "A goblin's sword falls. The goblin's shield breaks."
         );
     }
@@ -4480,13 +4746,13 @@ mod tests {
         let cache = TemplateCache::new(100);
         let template = cache
             .get_or_compile("{A:source} [source:walk]. {A:source} [source:run].")
-            .unwrap();
+            .expect("Failed to compile template");
 
         let ctx = RenderContext::new("char_1").with_entity("source", &player);
 
         // The 'A' and 'The' upgrades are both cleanly suppressed because the entity is the viewer
         assert_eq!(
-            PerspectiveEngine::render(&template, &ctx).unwrap(),
+            PerspectiveEngine::render(&template, &ctx).expect("Failed to render template"),
             "You walk. You run."
         );
     }
@@ -4529,14 +4795,14 @@ mod tests {
         let cache = TemplateCache::new(100);
         let template = cache
             .get_or_compile("{A:source} [source:draw] {a:weapon}. {A:weapon} [weapon:be] sharp.")
-            .unwrap();
+            .expect("Failed to compile template");
 
         let ctx = RenderContext::new("char_1")
             .with_entity("source", &goblin)
             .with_entity("weapon", &rusty_sword);
 
         assert_eq!(
-            PerspectiveEngine::render(&template, &ctx).unwrap(),
+            PerspectiveEngine::render(&template, &ctx).expect("Failed to render template"),
             "A goblin draws a rusty sword. The rusty sword is sharp."
         );
     }
@@ -4611,18 +4877,26 @@ mod tests {
         let ctx = RenderContext::new("viewer");
 
         // 1. [SB] forces a sentence boundary
-        let t_sb = cache.get_or_compile("wait, [SB]what?").unwrap();
-        let out_sb = PerspectiveEngine::render(&t_sb, &ctx).unwrap();
+        let t_sb = cache
+            .get_or_compile("wait, [SB]what?")
+            .expect("Failed to compile template");
+        let out_sb = PerspectiveEngine::render(&t_sb, &ctx).expect("Failed to render template");
         assert_eq!(out_sb, "Wait, What?");
 
         // 2. [NO_SB] suppresses a sentence boundary
-        let t_no_sb = cache.get_or_compile("apples vs.[NO_SB] oranges.").unwrap();
-        let out_no_sb = PerspectiveEngine::render(&t_no_sb, &ctx).unwrap();
+        let t_no_sb = cache
+            .get_or_compile("apples vs.[NO_SB] oranges.")
+            .expect("Failed to compile template");
+        let out_no_sb =
+            PerspectiveEngine::render(&t_no_sb, &ctx).expect("Failed to render template");
         assert_eq!(out_no_sb, "Apples vs. oranges.");
 
         // 3. Ensuring tags don't output stray whitespace and chain well
-        let t_combined = cache.get_or_compile("one.[NO_SB] two[SB] three.").unwrap();
-        let out_combined = PerspectiveEngine::render(&t_combined, &ctx).unwrap();
+        let t_combined = cache
+            .get_or_compile("one.[NO_SB] two[SB] three.")
+            .expect("Failed to compile template");
+        let out_combined =
+            PerspectiveEngine::render(&t_combined, &ctx).expect("Failed to render template");
         assert_eq!(out_combined, "One. two Three.");
     }
 
@@ -4648,13 +4922,13 @@ mod tests {
         // 1. Direct Entity Tags
         let t1 = cache
             .get_or_compile("{A:source} and {a:other} arrive.")
-            .unwrap();
+            .expect("Failed to compile template");
         let ctx1 = RenderContext::new("char_1")
             .with_entity("source", &wolf1)
             .with_entity("other", &wolf2);
 
         assert_eq!(
-            PerspectiveEngine::render(&t1, &ctx1).unwrap(),
+            PerspectiveEngine::render(&t1, &ctx1).expect("Failed to render template"),
             "A wolf and a large wolf arrive."
         );
 
@@ -4664,10 +4938,10 @@ mod tests {
         // 2. Pronoun Fallback Upgrades
         let t2 = cache
             .get_or_compile("{A:source} and {a:other} arrive. {other:Subj} [other:howl].")
-            .unwrap();
+            .expect("Failed to compile template");
 
         assert_eq!(
-            PerspectiveEngine::render(&t2, &ctx1).unwrap(),
+            PerspectiveEngine::render(&t2, &ctx1).expect("Failed to render template"),
             "A wolf and a large wolf arrive. The large wolf howls."
         );
     }
@@ -4693,13 +4967,13 @@ mod tests {
 
         let t1 = cache
             .get_or_compile("{A:source} and {a:other} arrive.")
-            .unwrap();
+            .expect("Failed to compile template");
         let ctx1 = RenderContext::new("char_1")
             .with_entity("source", &wolf1)
             .with_entity("other", &wolf2);
 
         assert_eq!(
-            PerspectiveEngine::render(&t1, &ctx1).unwrap(),
+            PerspectiveEngine::render(&t1, &ctx1).expect("Failed to render template"),
             "A wolf and another wolf arrive."
         );
     }
@@ -4732,14 +5006,14 @@ mod tests {
 
         let t1 = cache
             .get_or_compile("{A:w1} enters. {A:w2} enters. {A:w3} enters.")
-            .unwrap();
+            .expect("Failed to compile template");
         let ctx1 = RenderContext::new("char_1")
             .with_entity("w1", &wolf_scrawny)
             .with_entity("w2", &wolf_large1)
             .with_entity("w3", &wolf_large2);
 
         assert_eq!(
-            PerspectiveEngine::render(&t1, &ctx1).unwrap(),
+            PerspectiveEngine::render(&t1, &ctx1).expect("Failed to render template"),
             "A wolf enters. A large wolf enters. Another large wolf enters."
         );
     }
@@ -4780,7 +5054,7 @@ mod tests {
         // Jim's hidden long name should NOT prevent the wolves from disambiguating to "large wolf"
         let t1 = cache
             .get_or_compile("{A:jim} enters. {A:w1} enters. {A:w2} enters. {A:w3} enters.")
-            .unwrap();
+            .expect("Failed to compile template");
         let ctx1 = RenderContext::new("char_1")
             .with_entity("jim", &jim)
             .with_entity("w1", &wolf_scrawny)
@@ -4788,7 +5062,7 @@ mod tests {
             .with_entity("w3", &wolf_large2);
 
         assert_eq!(
-            PerspectiveEngine::render(&t1, &ctx1).unwrap(),
+            PerspectiveEngine::render(&t1, &ctx1).expect("Failed to render template"),
             "Jim enters. A wolf enters. A large wolf enters. Another large wolf enters."
         );
     }
@@ -4970,13 +5244,13 @@ mod tests {
         // w1 goes FIRST. It doesn't know w2 exists yet, so it uses its short name.
         let t = cache
             .get_or_compile("{A:w1} and {a:w2} arrive. {w1:Subj} [w1:growl]. {w2:Subj} [w2:bark].")
-            .unwrap();
+            .expect("Failed to compile template");
         let ctx = RenderContext::new("viewer")
             .with_entity("w1", &w1)
             .with_entity("w2", &w2);
 
         assert_eq!(
-            PerspectiveEngine::render(&t, &ctx).unwrap(),
+            PerspectiveEngine::render(&t, &ctx).expect("Failed to render template"),
             "A wolf and another wolf arrive. The large wolf growls. The wolf barks."
         );
     }
@@ -5002,13 +5276,13 @@ mod tests {
         // w2 goes FIRST. When w1 goes second, it sees w2 and upgrades to its long name immediately!
         let t = cache
             .get_or_compile("{A:w2} and {a:w1} arrive. {w2:Subj} [w2:bark]. {w1:Subj} [w1:growl].")
-            .unwrap();
+            .expect("Failed to compile template");
         let ctx = RenderContext::new("viewer")
             .with_entity("w1", &w1)
             .with_entity("w2", &w2);
 
         assert_eq!(
-            PerspectiveEngine::render(&t, &ctx).unwrap(),
+            PerspectiveEngine::render(&t, &ctx).expect("Failed to render template"),
             "A wolf and a large wolf arrive. The wolf barks. The large wolf growls."
         );
     }
@@ -5033,14 +5307,14 @@ mod tests {
 
         let t = cache
             .get_or_compile("{A:w1} and {a:w2} arrive. {w1:Subj} [w1:growl]. {w2:Subj} [w2:bark].")
-            .unwrap();
+            .expect("Failed to compile template");
 
         // Without lookahead (left-to-right causal pop-in)
         let ctx_default = RenderContext::new("viewer")
             .with_entity("w1", &w1)
             .with_entity("w2", &w2);
         assert_eq!(
-            PerspectiveEngine::render(&t, &ctx_default).unwrap(),
+            PerspectiveEngine::render(&t, &ctx_default).expect("Failed to render template"),
             "A wolf and another wolf arrive. The large wolf growls. The wolf barks."
         );
 
@@ -5051,7 +5325,7 @@ mod tests {
             .with_entity("w2", &w2)
             .with_lookahead(true);
         assert_eq!(
-            PerspectiveEngine::render(&t, &ctx_lookahead).unwrap(),
+            PerspectiveEngine::render(&t, &ctx_lookahead).expect("Failed to render template"),
             "A large wolf and a wolf arrive. The large wolf growls. The wolf barks."
         );
     }
@@ -5132,7 +5406,7 @@ mod tests {
         let cache = TemplateCache::new(100);
         let t = cache
             .get_or_compile("{A:w1} enters. {A:w2} enters. {A:w3} enters. {A:w4} enters.")
-            .unwrap();
+            .expect("Failed to compile template");
         let ctx = RenderContext::new("viewer")
             .with_entity("w1", &w1)
             .with_entity("w2", &w2)
@@ -5140,7 +5414,7 @@ mod tests {
             .with_entity("w4", &w4);
 
         assert_eq!(
-            PerspectiveEngine::render(&t, &ctx).unwrap(),
+            PerspectiveEngine::render(&t, &ctx).expect("Failed to render template"),
             "A wolf enters. Another wolf enters. A third wolf enters. A fourth wolf enters."
         );
     }
@@ -5189,9 +5463,9 @@ mod tests {
             .get_or_compile(
                 "{A:w2} returns. {w1:Subj} [w1:growl] at {the:w2}. {w2:Subj} [w2:flee].",
             )
-            .unwrap();
+            .expect("Failed to compile template");
         assert_eq!(
-            PerspectiveEngine::render(&t3, &ctx).unwrap(),
+            PerspectiveEngine::render(&t3, &ctx).expect("Failed to render template"),
             "Another wolf returns. The first wolf growls at the second wolf. The second wolf flees."
         );
     }
@@ -5219,11 +5493,11 @@ mod tests {
         // 1. Force Singular Verb on a Plural Entity
         let t1 = cache
             .get_or_compile("{One of the:orcs} [-orcs:bellow], and {-orcs:subj} [-orcs:charge]!")
-            .unwrap();
+            .expect("Failed to compile template");
         let ctx1 = RenderContext::new("viewer").with_entity("orcs", &orcs);
 
         assert_eq!(
-            PerspectiveEngine::render(&t1, &ctx1).unwrap(),
+            PerspectiveEngine::render(&t1, &ctx1).expect("Failed to render template"),
             "One of the orcs bellows, and it charges!"
         );
 
@@ -5233,13 +5507,13 @@ mod tests {
         // The engine should fallback gracefully to "One of the orcs" instead of "Some orcs".
         let t2 = cache
             .get_or_compile("{One of the:orcs} and {a:goblin} arrive. {-orcs:Subj} [-orcs:bellow].")
-            .unwrap();
+            .expect("Failed to compile template");
         let ctx2 = RenderContext::new("viewer")
             .with_entity("orcs", &orcs)
             .with_entity("goblin", &goblin);
 
         assert_eq!(
-            PerspectiveEngine::render(&t2, &ctx2).unwrap(),
+            PerspectiveEngine::render(&t2, &ctx2).expect("Failed to render template"),
             "One of the orcs and a goblin arrive. One of the orcs bellows."
         );
     }
@@ -5257,7 +5531,7 @@ mod tests {
         let cache = TemplateCache::new(100);
         let template = cache
             .get_or_compile("{-orcs:Subj} [-orcs:charge].")
-            .unwrap();
+            .expect("Failed to compile template");
 
         // 1. Director Stance (Present, Past, Future)
         let ctx_director_pres = RenderContext::new("viewer").with_entity("orcs", &orcs);
@@ -5269,17 +5543,20 @@ mod tests {
             .with_tense(crate::models::Tense::Future);
 
         assert_eq!(
-            PerspectiveEngine::render(&template, &ctx_director_pres).unwrap(),
+            PerspectiveEngine::render(&template, &ctx_director_pres)
+                .expect("Failed to render template"),
             "One of the orcs charges."
         );
 
         assert_eq!(
-            PerspectiveEngine::render(&template, &ctx_director_past).unwrap(),
+            PerspectiveEngine::render(&template, &ctx_director_past)
+                .expect("Failed to render template"),
             "One of the orcs charged."
         );
 
         assert_eq!(
-            PerspectiveEngine::render(&template, &ctx_director_fut).unwrap(),
+            PerspectiveEngine::render(&template, &ctx_director_fut)
+                .expect("Failed to render template"),
             "One of the orcs will charge."
         );
 
@@ -5335,9 +5612,9 @@ mod tests {
         // However, because `[-orcs:draw]` makes the orcs the active subject, `{-orcs:poss}` naturally collapses to "its"!
         let t = cache
             .get_or_compile("{A:goblin} snarls. {-orcs:Subj} [-orcs:draw] {-orcs:poss} blade!")
-            .unwrap();
+            .expect("Failed to compile template");
         assert_eq!(
-            PerspectiveEngine::render(&t, &ctx).unwrap(),
+            PerspectiveEngine::render(&t, &ctx).expect("Failed to render template"),
             "A goblin snarls. One of the orcs draws its blade!"
         );
 
@@ -5347,9 +5624,9 @@ mod tests {
         // But the builder can stack the `!` and `-` modifiers to force the pronoun anyway!
         let t2 = cache
             .get_or_compile("{A:goblin} snarls at {-orcs:obj} and steals {!-orcs:poss} blade!")
-            .unwrap();
+            .expect("Failed to compile template");
         assert_eq!(
-            PerspectiveEngine::render(&t2, &ctx).unwrap(),
+            PerspectiveEngine::render(&t2, &ctx).expect("Failed to render template"),
             "A goblin snarls at one of the orcs and steals its blade!"
         );
     }
@@ -5405,17 +5682,26 @@ mod tests {
         // We test three different stacking orders to prove the engine evaluates them identically!
         let t1 = cache
             .get_or_compile("{+!-source:subj} [+source:nod].")
-            .unwrap();
+            .expect("Failed to compile template");
         let t2 = cache
             .get_or_compile("{-!+source:subj} [+source:nod].")
-            .unwrap();
+            .expect("Failed to compile template");
         let t3 = cache
             .get_or_compile("{!+-source:subj} [+source:nod].")
-            .unwrap();
+            .expect("Failed to compile template");
 
-        assert_eq!(PerspectiveEngine::render(&t1, &ctx).unwrap(), "He nods.");
-        assert_eq!(PerspectiveEngine::render(&t2, &ctx).unwrap(), "He nods.");
-        assert_eq!(PerspectiveEngine::render(&t3, &ctx).unwrap(), "He nods.");
+        assert_eq!(
+            PerspectiveEngine::render(&t1, &ctx).expect("Failed to render template"),
+            "He nods."
+        );
+        assert_eq!(
+            PerspectiveEngine::render(&t2, &ctx).expect("Failed to render template"),
+            "He nods."
+        );
+        assert_eq!(
+            PerspectiveEngine::render(&t3, &ctx).expect("Failed to render template"),
+            "He nods."
+        );
     }
 
     #[test]
@@ -5484,9 +5770,9 @@ mod tests {
         // Neither 'A' nor 'a' should be rendered in the output.
         let t = cache
             .get_or_compile("{A:source} draws {a:source.weapon}.")
-            .unwrap();
+            .expect("Failed to compile template");
         assert_eq!(
-            PerspectiveEngine::render(&t, &ctx).unwrap(),
+            PerspectiveEngine::render(&t, &ctx).expect("Failed to render template"),
             "Arthur draws Excalibur."
         );
     }
@@ -5543,21 +5829,37 @@ mod tests {
 
         // As the active viewer, the engine should completely skip tracking occurrence permutations
         // for 'A', 'Some', and 'One of the' and simply inject the viewer pronoun "We".
-        let t1 = cache.get_or_compile("{A:source} [source:howl].").unwrap();
+        let t1 = cache
+            .get_or_compile("{A:source} [source:howl].")
+            .expect("Failed to compile template");
         let t2 = cache
             .get_or_compile("{Some:source} [source:howl].")
-            .unwrap();
+            .expect("Failed to compile template");
         let t3 = cache
             .get_or_compile("{One of the:source} [source:howl].")
-            .unwrap();
+            .expect("Failed to compile template");
 
-        assert_eq!(PerspectiveEngine::render(&t1, &ctx).unwrap(), "We howl.");
-        assert_eq!(PerspectiveEngine::render(&t2, &ctx).unwrap(), "We howl.");
-        assert_eq!(PerspectiveEngine::render(&t3, &ctx).unwrap(), "We howl.");
+        assert_eq!(
+            PerspectiveEngine::render(&t1, &ctx).expect("Failed to render template"),
+            "We howl."
+        );
+        assert_eq!(
+            PerspectiveEngine::render(&t2, &ctx).expect("Failed to render template"),
+            "We howl."
+        );
+        assert_eq!(
+            PerspectiveEngine::render(&t3, &ctx).expect("Failed to render template"),
+            "We howl."
+        );
 
         // But if the singular override is attached, it should accurately treat the pack as an individual "I"!
-        let t4 = cache.get_or_compile("{-source} [-source:howl].").unwrap();
-        assert_eq!(PerspectiveEngine::render(&t4, &ctx).unwrap(), "I howl.");
+        let t4 = cache
+            .get_or_compile("{-source} [-source:howl].")
+            .expect("Failed to compile template");
+        assert_eq!(
+            PerspectiveEngine::render(&t4, &ctx).expect("Failed to render template"),
+            "I howl."
+        );
     }
 
     #[test]
@@ -5590,27 +5892,27 @@ mod tests {
         // 1. Plural Indefinite Upgrades (Some -> A second set -> A third set)
         let t1 = cache
             .get_or_compile("{A:w1} arrive. {A:w2} arrive. {A:w3} arrive.")
-            .unwrap();
+            .expect("Failed to compile template");
         assert_eq!(
-            PerspectiveEngine::render(&t1, &ctx).unwrap(),
+            PerspectiveEngine::render(&t1, &ctx).expect("Failed to render template"),
             "Some wolves arrive. A second set of wolves arrive. A third set of wolves arrive."
         );
 
         // 2. Plural Demonstratives (This first set, That second set)
         let t2 = cache
             .get_or_compile("{This:w1} howl. {That:w2} howl.")
-            .unwrap();
+            .expect("Failed to compile template");
         assert_eq!(
-            PerspectiveEngine::render(&t2, &ctx).unwrap(),
+            PerspectiveEngine::render(&t2, &ctx).expect("Failed to render template"),
             "This first set of wolves howl. That second set of wolves howl."
         );
 
         // 3. "One of the" and "Some" explicitly preserving ordinals
         let t3 = cache
             .get_or_compile("{One of the:w1} howls. {Some:w2} howl.")
-            .unwrap();
+            .expect("Failed to compile template");
         assert_eq!(
-            PerspectiveEngine::render(&t3, &ctx).unwrap(),
+            PerspectiveEngine::render(&t3, &ctx).expect("Failed to render template"),
             "One of the first set of wolves howls. A second set of wolves howl."
         );
     }
@@ -5664,9 +5966,9 @@ mod tests {
 
         let t1 = cache
             .get_or_compile("{A:p1} arrive. {A:p2} arrive. {A:p3} arrive.")
-            .unwrap();
+            .expect("Failed to compile template");
         assert_eq!(
-            PerspectiveEngine::render(&t1, &ctx).unwrap(),
+            PerspectiveEngine::render(&t1, &ctx).expect("Failed to render template"),
             "Some wolves arrive. A second pack of wolves arrive. A third pack of wolves arrive."
         );
     }
@@ -5702,15 +6004,17 @@ mod tests {
         // The `!` prefix completely disables smart anaphora, bypassing collision tracking entirely.
         let t1 = cache
             .get_or_compile("{!A:w1}, {!another:w2}, and {!a:w3} arrive.")
-            .unwrap();
+            .expect("Failed to compile template");
         assert_eq!(
-            PerspectiveEngine::render(&t1, &ctx).unwrap(),
+            PerspectiveEngine::render(&t1, &ctx).expect("Failed to render template"),
             "A wolf, another wolf, and a wolf arrive."
         );
 
-        let t2 = cache.get_or_compile("{!The:w1} howls.").unwrap();
+        let t2 = cache
+            .get_or_compile("{!The:w1} howls.")
+            .expect("Failed to compile template");
         assert_eq!(
-            PerspectiveEngine::render(&t2, &ctx).unwrap(),
+            PerspectiveEngine::render(&t2, &ctx).expect("Failed to render template"),
             "The wolf howls."
         );
     }
@@ -5773,9 +6077,9 @@ mod tests {
         // and correctly routes the plural 'attack' verb!
         let t1 = cache
             .get_or_compile("{The:boss.minions} [boss.minions:attack]!")
-            .unwrap();
+            .expect("Failed to compile template");
         assert_eq!(
-            PerspectiveEngine::render(&t1, &ctx).unwrap(),
+            PerspectiveEngine::render(&t1, &ctx).expect("Failed to render template"),
             "The goblin and the slime attack!"
         );
     }
@@ -5794,24 +6098,26 @@ mod tests {
         let ctx = RenderContext::new("viewer").with_entity("orcs", &orcs);
 
         // Introduce the orcs so they are in anaphora memory
-        let t_intro = cache.get_or_compile("{The:orcs} are here.").unwrap();
-        let _ = PerspectiveEngine::render(&t_intro, &ctx).unwrap();
+        let t_intro = cache
+            .get_or_compile("{The:orcs} are here.")
+            .expect("Failed to compile template");
+        let _ = PerspectiveEngine::render(&t_intro, &ctx).expect("Failed to render template");
 
         // Without override (Standard Plural):
         let t1 = cache
             .get_or_compile("{orcs:Subj} [orcs:hurt] {orcs:reflex}.")
-            .unwrap();
+            .expect("Failed to compile template");
         assert_eq!(
-            PerspectiveEngine::render(&t1, &ctx).unwrap(),
+            PerspectiveEngine::render(&t1, &ctx).expect("Failed to render template"),
             "They hurt themselves."
         );
 
         // With override: Shifts from Plural -> Neutral (It/itself)
         let t2 = cache
             .get_or_compile("{-orcs:Subj} [-orcs:hurt] {-orcs:reflex}.")
-            .unwrap();
+            .expect("Failed to compile template");
         assert_eq!(
-            PerspectiveEngine::render(&t2, &ctx).unwrap(),
+            PerspectiveEngine::render(&t2, &ctx).expect("Failed to render template"),
             "It hurts itself."
         );
     }
@@ -5834,9 +6140,9 @@ mod tests {
             .get_or_compile(
                 "{avengers} [avengers:assemble] and [avengers:defend] {avengers:reflex}.",
             )
-            .unwrap();
+            .expect("Failed to compile template");
         assert_eq!(
-            PerspectiveEngine::render(&t1, &ctx).unwrap(),
+            PerspectiveEngine::render(&t1, &ctx).expect("Failed to render template"),
             "The Avengers assemble and defend themselves."
         );
 
@@ -5845,9 +6151,9 @@ mod tests {
             .get_or_compile(
                 "{-avengers} [-avengers:assemble] and [-avengers:defend] {-avengers:reflex}.",
             )
-            .unwrap();
+            .expect("Failed to compile template");
         assert_eq!(
-            PerspectiveEngine::render(&t2, &ctx).unwrap(),
+            PerspectiveEngine::render(&t2, &ctx).expect("Failed to render template"),
             "The Avengers assembles and defends itself."
         );
     }
@@ -5937,8 +6243,8 @@ mod tests {
         let cache = TemplateCache::new(100);
         let t = cache
             .get_or_compile("{A:w1}, {a:orc}, and {a:w2} arrive.")
-            .unwrap();
-        PerspectiveEngine::render(&t, &ctx).unwrap();
+            .expect("Failed to compile template");
+        PerspectiveEngine::render(&t, &ctx).expect("Failed to render template");
 
         // Exact match via name
         let matches = ctx.resolve_target("the orc");
@@ -6031,7 +6337,7 @@ mod tests {
         assert_eq!(
             matches[0]
                 .resolve_deep_entity()
-                .unwrap()
+                .expect("Failed to resolve deep entity")
                 .display_name_for("viewer"),
             "rusty sword"
         );
@@ -6153,7 +6459,7 @@ mod tests {
         assert_eq!(
             matches[0]
                 .resolve_deep_entity()
-                .unwrap()
+                .expect("Failed to resolve deep entity")
                 .display_name_for("viewer"),
             "leather hilt"
         );
@@ -6168,7 +6474,7 @@ mod tests {
         assert_eq!(
             matches2[0]
                 .resolve_deep_entity()
-                .unwrap()
+                .expect("Failed to resolve deep entity")
                 .display_name_for("viewer"),
             "leather hilt"
         );
@@ -6265,8 +6571,10 @@ mod tests {
             .with_entity("r2", &ring2);
 
         let cache = TemplateCache::new(100);
-        let t = cache.get_or_compile("{r1} and {r2} are here.").unwrap();
-        PerspectiveEngine::render(&t, &ctx).unwrap(); // Seeds ordinals
+        let t = cache
+            .get_or_compile("{r1} and {r2} are here.")
+            .expect("Failed to compile template");
+        PerspectiveEngine::render(&t, &ctx).expect("Failed to render template"); // Seeds ordinals
 
         let m1 = ctx.resolve_target("first ring");
         assert_eq!(m1.len(), 1);
@@ -6339,8 +6647,8 @@ mod tests {
         // their long name and assign ordinals.
         let t = cache
             .get_or_compile("{A:w_normal}, {a:dw1}, and {a:dw2} arrive.")
-            .unwrap();
-        PerspectiveEngine::render(&t, &ctx).unwrap();
+            .expect("Failed to compile template");
+        PerspectiveEngine::render(&t, &ctx).expect("Failed to render template");
 
         let m1 = ctx.resolve_target("the first dire wolf");
         assert_eq!(m1.len(), 1);
@@ -6728,8 +7036,10 @@ mod tests {
 
         // Seed the ordinals by rendering a template
         let cache = TemplateCache::new(100);
-        let t = cache.get_or_compile("{A:o1} and {a:o2} arrive.").unwrap();
-        PerspectiveEngine::render(&t, &ctx).unwrap();
+        let t = cache
+            .get_or_compile("{A:o1} and {a:o2} arrive.")
+            .expect("Failed to compile template");
+        PerspectiveEngine::render(&t, &ctx).expect("Failed to render template");
 
         let m1 = ctx.resolve_target("the first orc's sword");
         assert_eq!(m1.len(), 1);
@@ -6849,8 +7159,10 @@ mod tests {
             .with_entity("g1", &goblin);
 
         let cache = TemplateCache::new(100);
-        let t = cache.get_or_compile("{A:o1} and {a:o2} arrive.").unwrap();
-        PerspectiveEngine::render(&t, &ctx).unwrap();
+        let t = cache
+            .get_or_compile("{A:o1} and {a:o2} arrive.")
+            .expect("Failed to compile template");
+        PerspectiveEngine::render(&t, &ctx).expect("Failed to render template");
 
         // 1. Postfix syntax for ambiguous items
         let m1 = ctx.resolve_target("orc 1");
@@ -6987,9 +7299,9 @@ mod tests {
         // 1. Render the encounter (Seeds Ordinals and Anaphora memory)
         let t_intro = cache
             .get_or_compile("{A:g1} and {a:g2} ambush {player}!")
-            .unwrap();
+            .expect("Failed to compile template");
         assert_eq!(
-            PerspectiveEngine::render(&t_intro, &ctx).unwrap(),
+            PerspectiveEngine::render(&t_intro, &ctx).expect("Failed to render template"),
             "A goblin and another goblin ambush you!"
         );
 
@@ -7001,18 +7313,18 @@ mod tests {
         // 3. Render the player's combat action
         let t_attack = cache
             .get_or_compile("{player} [player:slash] {the:g1} with {player:poss} {player.weapon}.")
-            .unwrap();
+            .expect("Failed to compile template");
         assert_eq!(
-            PerspectiveEngine::render(&t_attack, &ctx).unwrap(),
+            PerspectiveEngine::render(&t_attack, &ctx).expect("Failed to render template"),
             "You slash the first goblin with your glowing sword."
         );
 
         // 4. Enemy 2 retaliates
         let t_retaliate = cache
             .get_or_compile("{The:g2} [g2:swing] {g2:poss} {g2.weapon} at {player:obj}!")
-            .unwrap();
+            .expect("Failed to compile template");
         assert_eq!(
-            PerspectiveEngine::render(&t_retaliate, &ctx).unwrap(),
+            PerspectiveEngine::render(&t_retaliate, &ctx).expect("Failed to render template"),
             "The second goblin swings its wooden club at you!"
         );
 
@@ -7022,7 +7334,9 @@ mod tests {
         assert_eq!(targets_alias[0].key, "g2");
         assert_eq!(targets_alias[0].path.as_deref(), Some("weapon"));
 
-        let nested_item = targets_alias[0].resolve_deep_entity().unwrap();
+        let nested_item = targets_alias[0]
+            .resolve_deep_entity()
+            .expect("Failed to resolve deep entity");
         assert_eq!(nested_item.display_name_for("viewer"), "wooden club");
 
         // 6. Simulate Player Input: "attack it" (Ambiguous pronoun, both neutral goblins are in memory)
@@ -7079,8 +7393,8 @@ mod tests {
         let cache = TemplateCache::new(100);
         let t = cache
             .get_or_compile("{A:w1}, {a:w2}, and {a:o1} arrive.")
-            .unwrap();
-        PerspectiveEngine::render(&t, &ctx).unwrap();
+            .expect("Failed to compile template");
+        PerspectiveEngine::render(&t, &ctx).expect("Failed to render template");
 
         // 1. Case-insensitive exact match downgrading to ASCII
         let m1 = ctx.resolve_target("angry wolf");
@@ -7359,15 +7673,17 @@ mod tests {
         // The parser safely accepts trailing apostrophes and evaluates them as possessives!
         let t1 = cache
             .get_or_compile("You hear {the:wolves'} howls.")
-            .unwrap();
-        let t2 = cache.get_or_compile("You take {the:boss'} gold.").unwrap();
+            .expect("Failed to compile template");
+        let t2 = cache
+            .get_or_compile("You take {the:boss'} gold.")
+            .expect("Failed to compile template");
 
         assert_eq!(
-            PerspectiveEngine::render(&t1, &ctx).unwrap(),
+            PerspectiveEngine::render(&t1, &ctx).expect("Failed to render template"),
             "You hear the wolves' howls."
         );
         assert_eq!(
-            PerspectiveEngine::render(&t2, &ctx).unwrap(),
+            PerspectiveEngine::render(&t2, &ctx).expect("Failed to render template"),
             "You take the boss's gold."
         );
     }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -6865,6 +6865,12 @@ mod tests {
         assert_eq!(m_first.len(), 1);
         assert_eq!(m_first[0].key, "o1");
 
+        let m_bad_post = ctx.resolve_target("orc1");
+        assert_eq!(m_bad_post.len(), 0);
+
+        let m_bad_pre = ctx.resolve_target("firstorc");
+        assert_eq!(m_bad_pre.len(), 0);
+
         // 2. Postfix syntax for unambiguous items (defaults to 1)
         let m3 = ctx.resolve_target("goblin 1");
         assert_eq!(m3.len(), 1);
@@ -7022,5 +7028,347 @@ mod tests {
         // 6. Simulate Player Input: "attack it" (Ambiguous pronoun, both neutral goblins are in memory)
         let targets_pronoun = ctx.resolve_target("it");
         assert_eq!(targets_pronoun.len(), 2);
+    }
+
+    #[test]
+    fn test_resolve_target_unicode_optimizations() {
+        struct UnicodeMob {
+            name: &'static str,
+            aliases: &'static [&'static str],
+        }
+        impl TemplateEntity for UnicodeMob {
+            fn contains_viewer(&self, _: &str) -> bool {
+                false
+            }
+            fn gender(&self) -> Gender {
+                Gender::Neutral
+            }
+            fn is_plural(&self) -> bool {
+                false
+            }
+            fn is_proper_noun_for(&self, _: &str) -> bool {
+                false
+            }
+            fn display_name_for<'a>(&'a self, _: &str) -> Cow<'a, str> {
+                Cow::Borrowed(self.name)
+            }
+            fn aliases(&self) -> Option<&[&str]> {
+                Some(self.aliases)
+            }
+        }
+
+        let w1 = UnicodeMob {
+            name: "Ängry Wölf",
+            aliases: &["Grümpy Bëast"],
+        };
+        let w2 = UnicodeMob {
+            name: "Ängry Wölf",
+            aliases: &[],
+        }; // Identical name for ordinals testing
+        let o1 = UnicodeMob {
+            name: "Mÿstïc Ørc",
+            aliases: &[],
+        };
+
+        let ctx = RenderContext::new("viewer")
+            .with_entity("w1", &w1)
+            .with_entity("w2", &w2)
+            .with_entity("o1", &o1);
+
+        // Seed ordinals
+        let cache = TemplateCache::new(100);
+        let t = cache
+            .get_or_compile("{A:w1}, {a:w2}, and {a:o1} arrive.")
+            .unwrap();
+        PerspectiveEngine::render(&t, &ctx).unwrap();
+
+        // 1. Case-insensitive exact match downgrading to ASCII
+        let m1 = ctx.resolve_target("angry wolf");
+        assert_eq!(m1.len(), 2); // Matches both due to ordinals grouping
+
+        let m_orc = ctx.resolve_target("MYSTIC ORC"); // Fully uppercase ASCII string
+        assert_eq!(m_orc.len(), 1);
+        assert_eq!(m_orc[0].key, "o1");
+
+        // 2. Case-insensitive article stripping with ASCII
+        let m2 = ctx.resolve_target("The angry wolf");
+        assert_eq!(m2.len(), 2);
+
+        // 3. Aliases with ASCII and case difference
+        let m3 = ctx.resolve_target("grumpy beast");
+        assert_eq!(m3.len(), 1);
+        assert_eq!(m3[0].key, "w1");
+
+        // 4. Ordinals interacting directly with ASCII mapped to Unicode names
+        let m4 = ctx.resolve_target("first angry wolf");
+        assert_eq!(m4.len(), 1);
+        assert_eq!(m4[0].key, "w1");
+
+        let m5 = ctx.resolve_target("ANGRY WOLF 2"); // Postfix check with differing cases
+        assert_eq!(m5.len(), 1);
+        assert_eq!(m5[0].key, "w2");
+    }
+
+    #[test]
+    fn test_resolve_target_strict_diacritics() {
+        struct UnicodeMob {
+            name: &'static str,
+        }
+        impl TemplateEntity for UnicodeMob {
+            fn contains_viewer(&self, _: &str) -> bool {
+                false
+            }
+            fn gender(&self) -> Gender {
+                Gender::Neutral
+            }
+            fn is_plural(&self) -> bool {
+                false
+            }
+            fn is_proper_noun_for(&self, _: &str) -> bool {
+                false
+            }
+            fn display_name_for<'a>(&'a self, _: &str) -> Cow<'a, str> {
+                Cow::Borrowed(self.name)
+            }
+        }
+
+        let w1 = UnicodeMob {
+            name: "Ängry Wölf"
+        };
+
+        // Enable strict diacritic matching!
+        let ctx = RenderContext::new("viewer")
+            .with_entity("w1", &w1)
+            .with_strict_diacritics(true);
+
+        // 1. Exact match with correct diacritics still succeeds natively
+        assert_eq!(ctx.resolve_target("ängry wölf").len(), 1);
+
+        // 2. ASCII transliteration fails because strict mode is on!
+        assert_eq!(ctx.resolve_target("angry wolf").len(), 0);
+    }
+
+    #[test]
+    fn test_resolve_target_smart_quotes_and_spaces() {
+        struct Item {
+            name: &'static str,
+        }
+        impl TemplateEntity for Item {
+            fn contains_viewer(&self, _: &str) -> bool {
+                false
+            }
+            fn gender(&self) -> Gender {
+                Gender::Neutral
+            }
+            fn is_plural(&self) -> bool {
+                false
+            }
+            fn is_proper_noun_for(&self, _: &str) -> bool {
+                false
+            }
+            fn display_name_for<'a>(&'a self, _: &str) -> Cow<'a, str> {
+                Cow::Borrowed(self.name)
+            }
+        }
+
+        struct Actor {
+            name: String,
+            weapon: Item,
+        }
+        impl TemplateEntity for Actor {
+            fn contains_viewer(&self, viewer_id: &str) -> bool {
+                viewer_id == "char_1"
+            }
+            fn gender(&self) -> Gender {
+                Gender::Male
+            }
+            fn is_plural(&self) -> bool {
+                false
+            }
+            fn is_proper_noun_for(&self, _: &str) -> bool {
+                true
+            }
+            fn display_name_for<'a>(&'a self, _: &str) -> Cow<'a, str> {
+                Cow::Borrowed(&self.name)
+            }
+            fn get_property(&self, property_name: &str) -> Option<&dyn TemplateEntity> {
+                match property_name {
+                    "sword" => Some(&self.weapon),
+                    _ => None,
+                }
+            }
+        }
+
+        let player = Actor {
+            name: "Aldran".to_string(),
+            weapon: Item {
+                name: "rusty sword",
+            },
+        };
+        let robot = Actor {
+            name: "Robot 5".to_string(),
+            weapon: Item {
+                name: "laser sword",
+            },
+        };
+
+        let ctx = RenderContext::new("char_2")
+            .with_entity("aldran", &player)
+            .with_entity("robot", &robot);
+
+        // 1. Smart quotes
+        let m1 = ctx.resolve_target("Aldran’s sword");
+        assert_eq!(m1[0].path.as_deref(), Some("sword"));
+
+        // 2. Errant spaces before apostrophes should NOT match
+        let m2 = ctx.resolve_target("Aldran 's sword");
+        assert_eq!(m2.len(), 0);
+
+        // 3. Multiple spaces after apostrophes
+        let m3 = ctx.resolve_target("Aldran's   sword");
+        assert_eq!(m3[0].path.as_deref(), Some("sword"));
+
+        // 4. Names with numbers
+        let m4 = ctx.resolve_target("Robot 5's sword");
+        assert_eq!(m4[0].key, "robot");
+    }
+
+    #[test]
+    fn test_resolve_target_possessive_ending_in_s() {
+        struct Item {
+            name: &'static str,
+        }
+        impl TemplateEntity for Item {
+            fn contains_viewer(&self, _: &str) -> bool {
+                false
+            }
+            fn gender(&self) -> Gender {
+                Gender::Neutral
+            }
+            fn is_plural(&self) -> bool {
+                false
+            }
+            fn is_proper_noun_for(&self, _: &str) -> bool {
+                false
+            }
+            fn display_name_for<'a>(&'a self, _: &str) -> Cow<'a, str> {
+                Cow::Borrowed(self.name)
+            }
+        }
+
+        struct Actor {
+            name: String,
+            weapon: Item,
+        }
+        impl TemplateEntity for Actor {
+            fn contains_viewer(&self, _: &str) -> bool {
+                false
+            }
+            fn gender(&self) -> Gender {
+                Gender::Male
+            }
+            fn is_plural(&self) -> bool {
+                false
+            }
+            fn is_proper_noun_for(&self, _: &str) -> bool {
+                true
+            }
+            fn display_name_for<'a>(&'a self, _: &str) -> Cow<'a, str> {
+                Cow::Borrowed(&self.name)
+            }
+            fn get_property(&self, property_name: &str) -> Option<&dyn TemplateEntity> {
+                match property_name {
+                    "sword" | "claws" => Some(&self.weapon),
+                    _ => None,
+                }
+            }
+        }
+
+        let lucas = Actor {
+            name: "Lucas".to_string(),
+            weapon: Item {
+                name: "rusty sword",
+            },
+        };
+        let wolves = Actor {
+            name: "wolves".to_string(),
+            weapon: Item {
+                name: "sharp claws",
+            },
+        };
+
+        let ctx = RenderContext::new("viewer")
+            .with_entity("lucas", &lucas)
+            .with_entity("wolves", &wolves);
+
+        // 1. Singular name ending in 's' using trailing apostrophe
+        let m1 = ctx.resolve_target("Lucas' sword");
+        assert_eq!(m1.len(), 1);
+        assert_eq!(m1[0].key, "lucas");
+        assert_eq!(m1[0].path.as_deref(), Some("sword"));
+
+        // 2. Singular name ending in 's' using `'s`
+        let m2 = ctx.resolve_target("Lucas's sword");
+        assert_eq!(m2.len(), 1);
+        assert_eq!(m2[0].key, "lucas");
+        assert_eq!(m2[0].path.as_deref(), Some("sword"));
+
+        // 3. Plural noun ending in 's' using trailing apostrophe
+        let m3 = ctx.resolve_target("the wolves' claws");
+        assert_eq!(m3.len(), 1);
+        assert_eq!(m3[0].key, "wolves");
+        assert_eq!(m3[0].path.as_deref(), Some("claws"));
+
+        // 4. Incomplete plural possessive should NOT match the base entity
+        let m4 = ctx.resolve_target("the wolves'");
+        assert_eq!(m4.len(), 0);
+
+        // 5. Ensure trailing sentence punctuation is still safely stripped
+        let m5 = ctx.resolve_target("the wolves.");
+        assert_eq!(m5.len(), 1);
+
+        // 6. Incomplete singular possessives ending in 's' should NOT match the base entity
+        let m6 = ctx.resolve_target("Lucas'");
+        assert_eq!(m6.len(), 0);
+        assert_eq!(ctx.resolve_target("Lucas's").len(), 0);
+    }
+
+    #[test]
+    fn test_trailing_apostrophe_in_template_tag() {
+        let wolves = MockEntity {
+            id: "mob_1".to_string(),
+            name: "wolves".to_string(),
+            gender: Gender::Plural,
+            is_plural: true,
+            is_proper_noun: false,
+        };
+        let boss = MockEntity {
+            id: "mob_2".to_string(),
+            name: "boss".to_string(),
+            gender: Gender::Neutral,
+            is_plural: false,
+            is_proper_noun: false,
+        };
+
+        let cache = TemplateCache::new(100);
+        let ctx = RenderContext::new("viewer")
+            .with_entity("wolves", &wolves)
+            .with_entity("boss", &boss);
+
+        // Builders might naturally write `{wolves'}` instead of `{wolves's}` to denote possession.
+        // The parser safely accepts trailing apostrophes and evaluates them as possessives!
+        let t1 = cache
+            .get_or_compile("You hear {the:wolves'} howls.")
+            .unwrap();
+        let t2 = cache.get_or_compile("You take {the:boss'} gold.").unwrap();
+
+        assert_eq!(
+            PerspectiveEngine::render(&t1, &ctx).unwrap(),
+            "You hear the wolves' howls."
+        );
+        assert_eq!(
+            PerspectiveEngine::render(&t2, &ctx).unwrap(),
+            "You take the boss's gold."
+        );
     }
 }


### PR DESCRIPTION
- Implement tests for resolving target pronouns, names, and ordinals.
- Include tests for nested sub-elements and possessive references.
- Validate handling of ambiguous matches and aliases for entities.
- Ensure proper resolution of group entities and their aliases.
- Test for long descriptions and ordinals with embedded articles.
- Introduce strict resolution methods to filter uncertain matches.
- Cover end-to-end combat interactions, including player actions and enemy responses.