### PR TITLE
feat: Enhance adjective handling in target resolution

### DIFF
--- a/.gemini/styleguide.md
+++ b/.gemini/styleguide.md
@@ -18,7 +18,7 @@
 These are fundamental rules that must be followed to ensure the quality, stability, and correctness of the server.
 
 * **No `unsafe` Code:** The use of `unsafe` blocks is strictly prohibited. All code must be written in safe Rust.
-* **No Panics:** With the exception of tests, the code must be robust and must not panic under any circumstances. Avoid using code that can panic, such as `unwrap()`, `expect()`, `unreachable!()`, or index operations that can go out of bounds. Always handle potential errors gracefully, typically by propagating a `Result`. (commandline tools may call exit())
+* **No Panics:** With the exception of tests, the code must be robust and must not panic under any circumstances. Avoid using code that can panic, such as `unwrap()`, `expect()`, `unreachable!()`, or index operations that can go out of bounds. Always handle potential errors gracefully, typically by propagating a `Result`.
 * **DRY (Don't Repeat Yourself):** Strive to keep the codebase as DRY as possible. Abstract and reuse common logic, data structures, and patterns to improve maintainability and reduce the chance of bugs.
 * **Dependency Management:** Before adding a new dependency, check if a reasonable alternative already exists within the project's current dependency tree. The goal is to keep the number of dependencies minimal.
 * **Keep Documentation Updated:** Any change to the code must be accompanied by corresponding changes to its documentation. Out-of-date documentation is a source of bugs.

--- a/README.md
+++ b/README.md
@@ -339,7 +339,7 @@ If you enable the Omniscient Lookahead feature (`ctx.with_lookahead(true)`), the
 
 As a final step before falling back to ordinals, the engine will attempt to disambiguate entities by prepending a unique set of adjectives from the `adjectives()` method. For example, if a "large red wolf" and a "large brown wolf" are in the same scene, the engine will recognize that "large" is not a unique descriptor, but "red" and "brown" are. It will automatically render them as "a red wolf" and "a brown wolf" instead of "the first wolf" and "the second wolf".
 
-To prevent exponential evaluation time on entities with many adjectives, the engine restricts its search combinations to the first 5 adjectives returned by the entity. This limit can be adjusted using `ctx.with_adjective_disambiguation_limit(size)`. The absolute maximum allowed size is 127 to prevent mathematical overflow.
+To prevent exponential evaluation time on entities with many adjectives, the engine restricts its search combinations to the first 5 adjectives returned by the entity. This limit can be adjusted using `ctx.with_adjective_disambiguation_limit(size)`. The absolute maximum allowed size is 63 to prevent mathematical overflow.
 
 #### **Best Practice: Pronoun Tags for Grammatical Case**
 

--- a/README.md
+++ b/README.md
@@ -264,6 +264,7 @@ let template = cache.get_or_compile("{source} [source:open] the door.")?;
   * `{key}`: Inserts the entity's display name.
   * `{key:case}`: Appends a pronoun case, defaulting to an indefinite article ("a") if the engine forces a noun fallback.
   * `{article:key}`: Prepends a specific article directly to the noun.
+  * `{article:adjectives:key:case}`: You can inject adjectives directly into the tag using the colon separator (e.g., `{A:glowing:sword}` or `{glowing:sword:obj}`). The engine automatically tracks these adjectives for target resolution.
   * `{article:owner's adjectives:target:case}`: Demarcates multi-word target keys from dynamically injected adjectives.
 * **Key:** The core identifier for the entity. 
   * *Capitalization:* Capitalize the first letter (`{Key}`) to force title-casing mid-sentence. 
@@ -318,8 +319,9 @@ The engine features an Anaphora Resolution system. It allows you to write templa
   * **Chaining:** You can render multiple templates in a row using the same context, and the engine will maintain narrative continuity across the templates.
   * **Game Ticks:** If your game loop spans across multiple server ticks or async events, you can extract the full narrative state using `let state = ctx.extract_anaphora()` and inject it into a brand new context later using `RenderContext::new(...).with_anaphora(state)`. This ensures ambiguity detection carries over.
 * **Memory Limits (LRU):** To prevent memory from growing unbounded during extremely long, continuous encounters, the anaphora memory acts as a Least-Recently-Used (LRU) cache defaulting to 15 entities. You can configure this limit using `ctx.with_anaphora_limit(size)`.
-* **Pinning & Manual Control:** In crowded scenarios, important characters might get pushed out of the LRU cache by a flurry of secondary actors. Protect them by pinning them into memory using `ctx.with_pinned_entity("key")` or `ctx.pin_anaphora("key")`. You can unpin them using `ctx.unpin_anaphora("key")`. You can also explicitly remove entities using `ctx.without_anaphora("key")` or `ctx.forget_anaphora("key")`.
+* **Pinning & Manual Control:** In crowded scenarios, important characters might get pushed out of the LRU cache by a flurry of secondary actors. Protect them by pinning them into memory using `ctx.with_pinned_entity("key")` or `ctx.pin_anaphora("key")`. You can check if an entity is currently pinned using `ctx.is_entity_pinned("key")`. You can unpin them using `ctx.unpin_anaphora("key")`. You can also explicitly remove entities using `ctx.without_anaphora("key")` or `ctx.forget_anaphora("key")`.
 * **Forcing Behaviors:** If you explicitly want to suppress the engine's anaphoric article upgrades or pronoun ambiguity fallbacks, you can use the `!` prefix modifier. Writing `{!a:source}` prevents "a" from upgrading to "the". Writing `{source:!subj}` forces the engine to output the pronoun even if it detects an ambiguous collision in the current memory.
+* **Querying Rendered State:** The engine tracks exactly how it described an entity to the viewer. You can check if an entity has been introduced to the scene using `ctx.has_seen_entity("key")`. You can retrieve the exact non-pronoun description (including dynamically injected adjectives or ordinals) using `ctx.latest_name("key")`. You can query the most recently assigned integer ordinal using `ctx.current_ordinal("key")` (useful for displaying numeric `[2]` badges in UIs), and retrieve any dynamically injected template adjectives using `ctx.inline_adjectives("key")`. You can also check the current grammatical focus using `ctx.active_subject()`. All of this data is preserved when extracting the `AnaphoraState`.
 * **Resetting Memory:** To manually clear the engine's memory, call `ctx.clear_anaphora()`. You should do this whenever narrative continuity is broken to prevent lingering pronoun references. Good times to call this include:
   * When a player moves to a new room or area.
   * When a significant amount of time passes between events.
@@ -337,7 +339,7 @@ If you enable the Omniscient Lookahead feature (`ctx.with_lookahead(true)`), the
 
 As a final step before falling back to ordinals, the engine will attempt to disambiguate entities by prepending a unique set of adjectives from the `adjectives()` method. For example, if a "large red wolf" and a "large brown wolf" are in the same scene, the engine will recognize that "large" is not a unique descriptor, but "red" and "brown" are. It will automatically render them as "a red wolf" and "a brown wolf" instead of "the first wolf" and "the second wolf".
 
-To prevent exponential evaluation time on entities with many adjectives, the engine restricts its search combinations to the first 5 adjectives returned by the entity. This limit can be adjusted using `ctx.with_adjective_disambiguation_limit(size)`.
+To prevent exponential evaluation time on entities with many adjectives, the engine restricts its search combinations to the first 5 adjectives returned by the entity. This limit can be adjusted using `ctx.with_adjective_disambiguation_limit(size)`. The absolute maximum allowed size is 127 to prevent mathematical overflow.
 
 #### **Best Practice: Pronoun Tags for Grammatical Case**
 

--- a/README.md
+++ b/README.md
@@ -75,6 +75,11 @@ impl TemplateEntity for Character {
     //     Some(&["large", "angry"])
     // }
 
+    // Optional: Provide a list of adjective synonyms for targeting.
+    // fn adjective_synonyms(&self) -> Option<&[&str]> {
+    //     Some(&["big", "huge"]) // for "large"
+    // }
+
     // Optional: Expose nested entities like body parts, targets, or equipment
     fn get_property(&self, property_name: &str) -> Option<&dyn TemplateEntity> {
         match property_name {
@@ -320,12 +325,19 @@ The engine features an Anaphora Resolution system. It allows you to write templa
   * When a significant amount of time passes between events.
   * At the start of a new, unrelated combat round or distinct paragraph.
   * *Why?* If you don't clear the memory between independent events, a template might output "He arrives." instead of "Aldran arrives." just because Aldran was the active subject of a completely unrelated event 5 minutes ago!
+  * *Auto-Clear:* If your contexts are short-lived or reused sequentially for independent events, you can enable `ctx.with_auto_clear(true)` to have the engine automatically flush the anaphora memory at the end of every successful render call.
 
 #### **Long Display Names & Collision Preemption**
 
 When two entities share the exact same short name (e.g., two entities named "wolf"), the engine automatically checks if either provides a `long_display_name_for` (e.g., "large wolf" or "dire wolf"). If one does, the engine dynamically upgrades the description to disambiguate them before resorting to numbered ordinals (preventing "the first wolf and the second wolf"). 
 
 If you enable the Omniscient Lookahead feature (`ctx.with_lookahead(true)`), the engine will preemptively use the long name on the very first mention. This prevents narrative "pop-in" where an entity is initially introduced as "a wolf" but suddenly upgrades to "the large wolf" sentences later when the second wolf arrives.
+
+#### Adjective Disambiguation
+
+As a final step before falling back to ordinals, the engine will attempt to disambiguate entities by prepending a unique set of adjectives from the `adjectives()` method. For example, if a "large red wolf" and a "large brown wolf" are in the same scene, the engine will recognize that "large" is not a unique descriptor, but "red" and "brown" are. It will automatically render them as "a red wolf" and "a brown wolf" instead of "the first wolf" and "the second wolf".
+
+To prevent exponential evaluation time on entities with many adjectives, the engine restricts its search combinations to the first 5 adjectives returned by the entity. This limit can be adjusted using `ctx.with_adjective_disambiguation_limit(size)`.
 
 #### **Best Practice: Pronoun Tags for Grammatical Case**
 
@@ -406,6 +418,22 @@ impl TemplateEntity for Character {
 }
 ```
 
+#### Adjective Synonyms
+
+Developers can implement the `adjective_synonyms()` method on their `TemplateEntity` to provide a list of alternative adjectives for targeting. This allows players to use more natural language (e.g., "get big sword") to target an item whose canonical adjective is `large`.
+
+These synonyms are only used for targeting and will not be used for rendering, preventing outputs like "the big large sword." 
+
+```rust
+impl TemplateEntity for Character {
+    // ... other methods ...
+
+    fn adjective_synonyms(&self) -> Option<&[&str]> {
+        Some(&["big", "huge"]) // for "large"
+    }
+}
+```
+
 #### Strict Diacritics (Unicode Transliteration)
 
 By default, the target resolution engine transliterates accents and diacritics to their closest ASCII equivalents. This means a player can type "angry wolf" to target an entity named "Ängry Wölf". If a game world relies heavily on constructed languages or specific lore terminology where diacritics matter, builders can disable this fuzzy matching.
@@ -414,6 +442,12 @@ By default, the target resolution engine transliterates accents and diacritics t
 let ctx = RenderContext::new("char_1").with_strict_diacritics(true);
 // "angry wolf" will now fail to match "Ängry Wölf" because the player must type it exactly.
 ```
+
+#### Target Memoization & Caching
+
+The `RenderContext` includes an internal memoization cache for target resolution. If a complex script or combat loop requests `ctx.resolve_target("the goblin")` multiple times in a single server tick, the engine will perform the string parsing and matching once and instantly return O(1) cached results for subsequent calls.
+
+The engine automatically invalidates this cache whenever the narrative state shifts (e.g., adding an entity, changing the stance, or updating the anaphora memory). However, if you mutate an entity's internal properties (like its name or adjectives) using interior mutability while the context is still alive, you should manually call `ctx.clear_target_cache()` to ensure the player's next input resolves against the new data.
 
 ### **7. Template Debugging**
 

--- a/README.md
+++ b/README.md
@@ -445,7 +445,7 @@ let ctx = RenderContext::new("char_1").with_strict_diacritics(true);
 
 #### Target Memoization & Caching
 
-The `RenderContext` includes an internal memoization cache for target resolution. If a complex script or combat loop requests `ctx.resolve_target("the goblin")` multiple times in a single server tick, the engine will perform the string parsing and matching once and instantly return O(1) cached results for subsequent calls.
+The `RenderContext` includes an internal memoization cache for target resolution. If a complex script or combat loop requests `ctx.resolve_target("the goblin")` multiple times in a single server tick, the engine will perform the string parsing and matching once and return *O(1)* cached results for subsequent calls. 
 
 The engine automatically invalidates this cache whenever the narrative state shifts (e.g., adding an entity, changing the stance, or updating the anaphora memory). However, if you mutate an entity's internal properties (like its name or adjectives) using interior mutability while the context is still alive, you should manually call `ctx.clear_target_cache()` to ensure the player's next input resolves against the new data.
 

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -163,6 +163,10 @@ impl PerspectiveEngine {
             }
         }
 
+        if ctx.auto_clear {
+            ctx.clear_anaphora();
+        }
+
         // 2. Pass the fully assembled base-case string to the typography post-processor
         Ok(post_process_typography(&raw_output))
     }
@@ -256,6 +260,120 @@ impl PerspectiveEngine {
         false
     }
 
+    fn try_adjective_disambiguation<'a>(
+        entity: &dyn TemplateEntity,
+        colliders: &[&dyn TemplateEntity],
+        base_name: &str,
+        limit: usize,
+    ) -> Option<(std::borrow::Cow<'a, str>, bool)> {
+        let entity_adjs = entity.adjectives().filter(|adjs| !adjs.is_empty())?;
+
+        let searchable_adjs = entity_adjs.get(..entity_adjs.len().min(limit))?;
+        if searchable_adjs.is_empty() {
+            return None;
+        }
+
+        let mut best_combo: Option<Vec<&str>> = None;
+        let mut min_colliders = colliders.len();
+
+        // Iterate through all non-empty subsets of the entity's adjectives to find the smallest set
+        // that minimizes the number of colliders sharing those adjectives.
+        for i in 1..(1 << searchable_adjs.len()) {
+            let mut subset = Vec::new();
+            for (j, &adj) in searchable_adjs.iter().enumerate() {
+                if (i >> j) & 1 == 1 {
+                    subset.push(adj);
+                }
+            }
+
+            let current_colliders = colliders
+                .iter()
+                .filter(|other| {
+                    if let Some(other_adjs) = other.adjectives() {
+                        let other_adjs_set: std::collections::HashSet<&str> =
+                            other_adjs.iter().copied().collect();
+                        subset.iter().all(|&adj| other_adjs_set.contains(adj))
+                    } else {
+                        false
+                    }
+                })
+                .count();
+
+            if current_colliders < min_colliders {
+                min_colliders = current_colliders;
+                best_combo = Some(subset);
+            } else if current_colliders == min_colliders {
+                // Prefer the smaller subset if it yields the same number of colliders.
+                if let Some(best) = &best_combo
+                    && subset.len() < best.len()
+                {
+                    best_combo = Some(subset);
+                }
+            }
+        }
+
+        if let Some(combo) = best_combo {
+            // To maintain a stable order, we sort the adjectives before joining.
+            let mut sorted_combo = combo;
+            sorted_combo.sort_unstable();
+            let prefix = sorted_combo.join(" ");
+            Some((
+                std::borrow::Cow::Owned(format!("{prefix} {base_name}")),
+                min_colliders > 0,
+            ))
+        } else {
+            None
+        }
+    }
+
+    #[inline]
+    #[allow(clippy::too_many_arguments)]
+    fn count_long_name_collisions(
+        ctx: &RenderContext,
+        effective_viewer: &str,
+        recent_borrow: &[crate::models::RecentEntity],
+        future_keys: &[&str],
+        pre_resolved: &HashMap<&str, &dyn TemplateEntity>,
+        params_key: &str,
+        short_name: &str,
+        long_name: &str,
+    ) -> usize {
+        let mut long_collisions = 0;
+
+        // Verify how many times the long name collides
+        let mut check_long = |other_key: &str, other_entity: &dyn TemplateEntity| {
+            if other_key != params_key {
+                let other_short = other_entity.display_name_for(effective_viewer);
+                // Only consider the other entity's long name if its short name is in the
+                // exact same collision group as our entity's short name (preventing phantoms).
+                if other_short == long_name
+                    || (other_short == short_name
+                        && other_entity
+                            .long_display_name_for(effective_viewer)
+                            .as_deref()
+                            == Some(long_name))
+                {
+                    long_collisions += 1;
+                }
+            }
+        };
+
+        for r in recent_borrow {
+            if let Ok(other_entity) = Self::get_entity(ctx, &r.key) {
+                check_long(&r.key, other_entity);
+            }
+        }
+        for &fk in future_keys {
+            if !recent_borrow.iter().any(|r| r.key == fk)
+                && let Some(&other_entity) = pre_resolved.get(fk)
+            {
+                check_long(fk, other_entity);
+            }
+        }
+
+        long_collisions
+    }
+
     #[inline]
     fn resolve_display_name<'a>(
         ctx: &'a RenderContext,
@@ -270,7 +388,7 @@ impl PerspectiveEngine {
 
         if !params.flags.no_smart() {
             let mut short_collisions = 0;
-            let mut unresolved_short_collisions = 0;
+            let mut unresolved_colliders: Vec<&'a dyn TemplateEntity> = Vec::new();
             let recent_borrow = ctx.recent_entities.borrow();
 
             // We use a closure here to iterate over the live `recent_borrow` and `future_keys`.
@@ -281,7 +399,7 @@ impl PerspectiveEngine {
                 if other_key != params.key
                     && other_entity.display_name_for(effective_viewer) == name
                 {
-                    short_collisions += 1;
+                    short_collisions += 1; // This counts all collisions, even those that will be resolved by long names.
 
                     // Determine if this other entity will vacate the short name by using its own long name
                     if !Self::check_will_vacate(
@@ -297,7 +415,7 @@ impl PerspectiveEngine {
                         // proved they are identical, saving us from binding a temporary variable.
                         name.as_ref(),
                     ) {
-                        unresolved_short_collisions += 1;
+                        unresolved_colliders.push(other_entity);
                     }
                 }
             };
@@ -315,50 +433,42 @@ impl PerspectiveEngine {
                 }
             }
 
-            name_collision = unresolved_short_collisions > 0;
+            name_collision = !unresolved_colliders.is_empty();
 
             if short_collisions > 0
                 && let Some(long_name) = entity.long_display_name_for(effective_viewer)
                 && long_name != name
             {
-                let mut long_collisions = 0;
-
-                // Verify how many times the long name collides
-                let mut check_long = |other_key: &str, other_entity: &'a dyn TemplateEntity| {
-                    if other_key != params.key {
-                        let other_short = other_entity.display_name_for(effective_viewer);
-                        // Only consider the other entity's long name if its short name is in the
-                        // exact same collision group as our entity's short name (preventing phantoms).
-                        if other_short == long_name
-                            || (other_short == name
-                                && other_entity
-                                    .long_display_name_for(effective_viewer)
-                                    .as_deref()
-                                    == Some(long_name.as_ref()))
-                        {
-                            long_collisions += 1;
-                        }
-                    }
-                };
-
-                for r in recent_borrow.iter() {
-                    if let Ok(other_entity) = Self::get_entity(ctx, &r.key) {
-                        check_long(&r.key, other_entity);
-                    }
-                }
-                for &fk in future_keys {
-                    if !recent_borrow.iter().any(|r| r.key == fk)
-                        && let Some(&other_entity) = pre_resolved.get(fk)
-                    {
-                        check_long(fk, other_entity);
-                    }
-                }
+                let long_collisions = Self::count_long_name_collisions(
+                    ctx,
+                    effective_viewer,
+                    &recent_borrow,
+                    future_keys,
+                    pre_resolved,
+                    params.key,
+                    name.as_ref(),
+                    long_name.as_ref(),
+                );
 
                 // If the long name is strictly more specific (has fewer collisions), use it!
                 if long_collisions < short_collisions {
                     name = long_name;
                     name_collision = long_collisions > 0;
                 }
+            }
+
+            // If a collision still exists, try to disambiguate by prepending unique adjectives.
+            if name_collision
+                && !entity.is_proper_noun_for(effective_viewer)
+                && let Some((adj_name, still_collides)) = Self::try_adjective_disambiguation(
+                    entity,
+                    &unresolved_colliders,
+                    &name,
+                    ctx.adjective_disambiguation_limit,
+                )
+            {
+                name = adj_name;
+                name_collision = still_collides;
             }
         }
 
@@ -389,6 +499,7 @@ impl PerspectiveEngine {
         name_collision: bool,
     ) -> Option<usize> {
         let mut ordinals = ctx.ordinals.borrow_mut();
+        ctx.target_cache.borrow_mut().clear();
         if !ordinals.contains_key(name) {
             ordinals.insert(
                 name.to_string(),
@@ -1546,6 +1657,7 @@ fn track_recent_entity(
     adjectives: Option<&str>,
 ) {
     let mut recents = ctx.recent_entities.borrow_mut();
+    ctx.target_cache.borrow_mut().clear();
 
     let mut new_adjs = Vec::new();
     if let Some(adj_str) = adjectives {

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -290,9 +290,7 @@ impl PerspectiveEngine {
                 .iter()
                 .filter(|other| {
                     if let Some(other_adjs) = other.adjectives() {
-                        let other_adjs_set: std::collections::HashSet<&str> =
-                            other_adjs.iter().copied().collect();
-                        subset.iter().all(|&adj| other_adjs_set.contains(adj))
+                        subset.iter().all(|&adj| other_adjs.contains(&adj))
                     } else {
                         false
                     }
@@ -1657,7 +1655,7 @@ fn track_recent_entity(
     adjectives: Option<&str>,
 ) {
     let mut recents = ctx.recent_entities.borrow_mut();
-        ctx.clear_target_cache();
+    ctx.clear_target_cache();
 
     let mut new_adjs = Vec::new();
     if let Some(adj_str) = adjectives {

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -268,7 +268,29 @@ impl PerspectiveEngine {
     ) -> Option<(std::borrow::Cow<'a, str>, bool)> {
         let entity_adjs = entity.adjectives().filter(|adjs| !adjs.is_empty())?;
 
-        let searchable_adjs = entity_adjs.get(..entity_adjs.len().min(limit))?;
+        // Prevent bitshift overflow by capping the limit to the bit-width of our counter
+        let safe_limit = limit.min((u128::BITS - 1) as usize);
+        if safe_limit == 0 {
+            return None;
+        }
+
+        // Filter out adjectives that are shared by ALL colliders, as they provide zero disambiguation value.
+        let mut searchable_adjs = Vec::with_capacity(entity_adjs.len().min(safe_limit));
+        for &adj in entity_adjs {
+            let shared_by_all = colliders.iter().all(|other| {
+                other
+                    .adjectives()
+                    .is_some_and(|other_adjs| other_adjs.contains(&adj))
+            });
+
+            if !shared_by_all {
+                searchable_adjs.push(adj);
+                if searchable_adjs.len() == safe_limit {
+                    break;
+                }
+            }
+        }
+
         if searchable_adjs.is_empty() {
             return None;
         }
@@ -276,10 +298,12 @@ impl PerspectiveEngine {
         let mut best_combo: Option<Vec<&str>> = None;
         let mut min_colliders = colliders.len();
 
+        let mut subset = Vec::with_capacity(searchable_adjs.len());
+
         // Iterate through all non-empty subsets of the entity's adjectives to find the smallest set
         // that minimizes the number of colliders sharing those adjectives.
-        for i in 1..(1 << searchable_adjs.len()) {
-            let mut subset = Vec::new();
+        for i in 1_u128..(1_u128 << searchable_adjs.len()) {
+            subset.clear();
             for (j, &adj) in searchable_adjs.iter().enumerate() {
                 if (i >> j) & 1 == 1 {
                     subset.push(adj);
@@ -299,13 +323,13 @@ impl PerspectiveEngine {
 
             if current_colliders < min_colliders {
                 min_colliders = current_colliders;
-                best_combo = Some(subset);
+                best_combo = Some(subset.clone());
             } else if current_colliders == min_colliders {
                 // Prefer the smaller subset if it yields the same number of colliders.
                 if let Some(best) = &best_combo
                     && subset.len() < best.len()
                 {
-                    best_combo = Some(subset);
+                    best_combo = Some(subset.clone());
                 }
             }
         }
@@ -622,7 +646,10 @@ impl PerspectiveEngine {
             Self::render_resolved_entity(
                 ctx,
                 raw_output,
-                params,
+                &EntityRefParams {
+                    adjectives: None,
+                    ..*params
+                },
                 entity,
                 effective_viewer,
                 params.article,
@@ -717,14 +744,6 @@ impl PerspectiveEngine {
         )?;
 
         raw_output.push(' ');
-
-        if let Some(adj) = params.adjectives {
-            if params.flags.contains(TagFlags::ALL_CAPS) {
-                apply_all_caps(adj, raw_output);
-            } else {
-                raw_output.push_str(adj);
-            }
-        }
 
         Ok(())
     }
@@ -865,7 +884,7 @@ impl PerspectiveEngine {
         if can_use_pronoun {
             if !already_seen {
                 update_memory(&ctx.last_mentioned, params.key);
-                track_recent_entity(ctx, params.key, entity, params.adjectives);
+                track_recent_entity(ctx, params.key, entity, params.adjectives, None);
             }
             let pronoun = resolve_pronoun(
                 effective_gender,
@@ -1003,7 +1022,13 @@ impl PerspectiveEngine {
         }
 
         update_memory(&ctx.last_mentioned, params.key);
-        track_recent_entity(ctx, params.key, entity, params.adjectives);
+        track_recent_entity(
+            ctx,
+            params.key,
+            entity,
+            params.adjectives,
+            Some(name.as_ref()),
+        );
 
         let active_params = EntityRefParams {
             key: params.key,
@@ -1011,7 +1036,7 @@ impl PerspectiveEngine {
             p_type: actual_p_type,
             owner_key: None,
             owner_flags: TagFlags::empty(),
-            adjectives: None,
+            adjectives: params.adjectives, // Pass the adjectives to the print functions
             flags: active_flags,
             ordinal,
         };
@@ -1107,12 +1132,31 @@ impl PerspectiveEngine {
             article_printed = true;
         }
 
-        let should_cap_noun =
-            if article_printed || (after_possessive && !active_params.flags.force_article()) {
-                active_params.flags.is_capitalized()
+        let mut adj_printed = false;
+        if let Some(adj) = active_params.adjectives {
+            let mut formatted_adj = String::new();
+            if active_params.flags.contains(TagFlags::ALL_CAPS) {
+                crate::typography::apply_all_caps(adj, &mut formatted_adj);
             } else {
-                cap_whole
-            };
+                formatted_adj.push_str(adj);
+            }
+
+            if !article_printed && cap_whole && !after_possessive {
+                raw_output.push_str(&crate::grammar::capitalize_first(&formatted_adj));
+            } else {
+                raw_output.push_str(&formatted_adj);
+            }
+            adj_printed = true;
+        }
+
+        let should_cap_noun = if article_printed
+            || adj_printed
+            || (after_possessive && !active_params.flags.force_article())
+        {
+            active_params.flags.is_capitalized()
+        } else {
+            cap_whole
+        };
 
         let name_cow = capitalize_cow(name, should_cap_noun);
         let name_str = name_cow.as_ref();
@@ -1414,6 +1458,15 @@ impl PerspectiveEngine {
             params.flags.article_capitalized() && first_visible_item,
         );
 
+        let mut adj_prefix = String::new();
+        if first_visible_item && let Some(adj) = params.adjectives {
+            if params.flags.contains(TagFlags::ALL_CAPS) {
+                crate::typography::apply_all_caps(adj, &mut adj_prefix);
+            } else {
+                adj_prefix.push_str(adj);
+            }
+        }
+
         let mut final_name = if let Some(resolved_art) = config.article_to_use.and_then(|art| {
             resolve_article(
                 art,
@@ -1424,7 +1477,14 @@ impl PerspectiveEngine {
                 article_flags,
             )
         }) {
-            std::borrow::Cow::Owned(format!("{}{name}", resolved_art.as_ref()))
+            std::borrow::Cow::Owned(format!("{}{adj_prefix}{name}", resolved_art.as_ref()))
+        } else if !adj_prefix.is_empty() {
+            let cap_adj = if params.flags.article_capitalized() && first_visible_item {
+                crate::grammar::capitalize_first(&adj_prefix)
+            } else {
+                adj_prefix
+            };
+            std::borrow::Cow::Owned(format!("{cap_adj}{name}"))
         } else {
             name
         };
@@ -1574,7 +1634,7 @@ impl PerspectiveEngine {
             let effective_viewer = effective_viewer_id(ctx, flags.force_3rd_person());
             update_memory(&ctx.active_subject, key);
             update_memory(&ctx.last_mentioned, key);
-            track_recent_entity(ctx, key, entity, None);
+            track_recent_entity(ctx, key, entity, None, None);
             (
                 entity.contains_viewer(effective_viewer),
                 entity.is_plural(),
@@ -1653,6 +1713,7 @@ fn track_recent_entity(
     key: &str,
     entity: &dyn TemplateEntity,
     adjectives: Option<&str>,
+    resolved_name: Option<&str>,
 ) {
     let mut recents = ctx.recent_entities.borrow_mut();
     ctx.clear_target_cache();
@@ -1692,6 +1753,9 @@ fn track_recent_entity(
                 item.adjectives.push(adj);
             }
         }
+        if let Some(rn) = resolved_name {
+            item.resolved_name = Some(rn.to_string());
+        }
         recents.push(item);
     } else {
         let mut flags = crate::models::RecentEntityFlags::empty();
@@ -1713,6 +1777,7 @@ fn track_recent_entity(
             gender: entity.gender(),
             flags,
             adjectives: new_adjs,
+            resolved_name: resolved_name.map(ToString::to_string),
         });
     }
 

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -499,7 +499,7 @@ impl PerspectiveEngine {
         name_collision: bool,
     ) -> Option<usize> {
         let mut ordinals = ctx.ordinals.borrow_mut();
-        ctx.target_cache.borrow_mut().clear();
+        ctx.clear_target_cache();
         if !ordinals.contains_key(name) {
             ordinals.insert(
                 name.to_string(),
@@ -1657,7 +1657,7 @@ fn track_recent_entity(
     adjectives: Option<&str>,
 ) {
     let mut recents = ctx.recent_entities.borrow_mut();
-    ctx.target_cache.borrow_mut().clear();
+        ctx.clear_target_cache();
 
     let mut new_adjs = Vec::new();
     if let Some(adj_str) = adjectives {

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -269,7 +269,7 @@ impl PerspectiveEngine {
         let entity_adjs = entity.adjectives().filter(|adjs| !adjs.is_empty())?;
 
         // Prevent bitshift overflow by capping the limit to the bit-width of our counter
-        let safe_limit = limit.min((u128::BITS - 1) as usize);
+        let safe_limit = limit.min((u64::BITS - 1) as usize);
         if safe_limit == 0 {
             return None;
         }
@@ -302,7 +302,7 @@ impl PerspectiveEngine {
 
         // Iterate through all non-empty subsets of the entity's adjectives to find the smallest set
         // that minimizes the number of colliders sharing those adjectives.
-        for i in 1_u128..(1_u128 << searchable_adjs.len()) {
+        for i in 1_u64..(1_u64 << searchable_adjs.len()) {
             subset.clear();
             for (j, &adj) in searchable_adjs.iter().enumerate() {
                 if (i >> j) & 1 == 1 {
@@ -646,10 +646,7 @@ impl PerspectiveEngine {
             Self::render_resolved_entity(
                 ctx,
                 raw_output,
-                &EntityRefParams {
-                    adjectives: None,
-                    ..*params
-                },
+                params,
                 entity,
                 effective_viewer,
                 params.article,

--- a/src/models.rs
+++ b/src/models.rs
@@ -207,6 +207,7 @@ pub struct RenderContext<'a> {
     pub anaphora_limit: usize,
     /// The maximum number of adjectives to evaluate when generating combinations for disambiguation.
     /// Capping this prevents exponential O(2^N) blowup if an entity has a large number of adjectives. Defaults to 5.
+    /// The absolute mathematical maximum is 127 to prevent bitshift overflow.
     pub adjective_disambiguation_limit: usize,
     /// If true, automatically clears the anaphora memory at the end of each successful render call.
     /// Defaults to false.
@@ -256,6 +257,8 @@ pub struct RecentEntity {
     pub flags: RecentEntityFlags,
     /// Dynamic inline adjectives injected during rendering.
     pub adjectives: Vec<String>,
+    /// The most recent non-pronoun name or description used for this entity during rendering.
+    pub resolved_name: Option<String>,
 }
 
 /// A snapshot of the engine's anaphora resolution memory.
@@ -272,6 +275,55 @@ pub struct AnaphoraState {
     pub recent_entities: Vec<RecentEntity>,
     /// Tracks the assignment of stable ordinals for display names.
     pub ordinals: HashMap<String, OrdinalState>,
+}
+
+impl AnaphoraState {
+    /// Retrieves the most recent non-pronoun name or description used for the specified entity.
+    /// This allows builders to determine if an entity was described as "red wolf" or "large wolf"
+    /// during disambiguation.
+    #[must_use]
+    pub fn latest_name(&self, key: &str) -> Option<&str> {
+        self.recent_entities
+            .iter()
+            .find(|r| r.key == key)
+            .and_then(|r| r.resolved_name.as_deref())
+    }
+
+    /// Retrieves the most recent ordinal assigned to the specified entity, if any.
+    #[must_use]
+    pub fn current_ordinal(&self, key: &str) -> Option<usize> {
+        for state in self.ordinals.values() {
+            if let Some(&ordinal) = state.members.get(key) {
+                return Some(ordinal);
+            }
+        }
+        None
+    }
+
+    /// Retrieves any inline adjectives that were dynamically injected for this entity via templates.
+    #[must_use]
+    pub fn inline_adjectives(&self, key: &str) -> Option<&[String]> {
+        self.recent_entities
+            .iter()
+            .find(|r| r.key == key)
+            .map(|r| r.adjectives.as_slice())
+    }
+
+    /// Checks if the specified entity is currently tracked in the anaphora memory.
+    /// This is useful for determining if an entity has already been introduced to the scene.
+    #[must_use]
+    pub fn has_seen_entity(&self, key: &str) -> bool {
+        self.recent_entities.iter().any(|r| r.key == key)
+    }
+
+    /// Checks if the specified entity is currently pinned in the anaphora memory.
+    #[must_use]
+    pub fn is_entity_pinned(&self, key: &str) -> bool {
+        self.recent_entities
+            .iter()
+            .find(|r| r.key == key)
+            .is_some_and(|r| r.flags.contains(RecentEntityFlags::IS_PINNED))
+    }
 }
 
 /// Represents a matched entity and an optional sub-element path requested by the user.
@@ -465,6 +517,56 @@ impl<'a> RenderContext<'a> {
         unique_matches
     }
 
+    /// Retrieves the most recent non-pronoun name or description used for the specified entity.
+    /// This allows builders to determine if an entity was described as "red wolf" or "large wolf"
+    /// during disambiguation.
+    #[must_use]
+    pub fn latest_name(&self, key: &str) -> Option<String> {
+        self.recent_entities
+            .borrow()
+            .iter()
+            .find(|r| r.key == key)
+            .and_then(|r| r.resolved_name.clone())
+    }
+
+    /// Retrieves the most recent ordinal assigned to the specified entity, if any.
+    #[must_use]
+    pub fn current_ordinal(&self, key: &str) -> Option<usize> {
+        for state in self.ordinals.borrow().values() {
+            if let Some(&ordinal) = state.members.get(key) {
+                return Some(ordinal);
+            }
+        }
+        None
+    }
+
+    /// Retrieves any inline adjectives that were dynamically injected for this entity via templates.
+    #[must_use]
+    pub fn inline_adjectives(&self, key: &str) -> Option<Vec<String>> {
+        self.recent_entities
+            .borrow()
+            .iter()
+            .find(|r| r.key == key)
+            .map(|r| r.adjectives.clone())
+    }
+
+    /// Checks if the specified entity is currently tracked in the anaphora memory.
+    /// This is useful for determining if an entity has already been introduced to the scene.
+    #[must_use]
+    pub fn has_seen_entity(&self, key: &str) -> bool {
+        self.recent_entities.borrow().iter().any(|r| r.key == key)
+    }
+
+    /// Checks if the specified entity is currently pinned in the anaphora memory.
+    #[must_use]
+    pub fn is_entity_pinned(&self, key: &str) -> bool {
+        self.recent_entities
+            .borrow()
+            .iter()
+            .find(|r| r.key == key)
+            .is_some_and(|r| r.flags.contains(RecentEntityFlags::IS_PINNED))
+    }
+
     /// Resolves a natural language description to the corresponding entities in the current context,
     /// strictly filtering out any matches where the requested sub-element path cannot be confirmed.
     ///
@@ -560,16 +662,25 @@ impl<'a> RenderContext<'a> {
         clean_desc: &str,
     ) -> bool {
         let recents = self.recent_entities.borrow();
-        let inline_adjectives = recents
-            .iter()
-            .find(|r| r.key == key)
-            .map_or(&[][..], |r| r.adjectives.as_slice());
+        let recent_entity = recents.iter().find(|r| r.key == key);
+        let inline_adjectives = recent_entity.map_or(&[][..], |r| r.adjectives.as_slice());
 
         let short_name = entity.display_name_for(self.viewer_id);
         let short_name_3rd = entity.display_name_for(NULL_VIEWER);
         let long_name = entity.long_display_name_for(self.viewer_id);
 
         let mut names_to_check = vec![short_name.as_ref(), short_name_3rd.as_ref()];
+
+        // FAST PATH: Check the exact rendered name (which includes disambiguated adjectives)
+        // to bypass the adjective validation loop entirely!
+        if let Some(r) = recent_entity
+            && let Some(ref rn) = r.resolved_name
+            && rn != short_name.as_ref()
+            && rn != short_name_3rd.as_ref()
+        {
+            names_to_check.push(rn.as_ref());
+        }
+
         if let Some(ref ln) = long_name {
             names_to_check.push(ln.as_ref());
         }
@@ -794,9 +905,24 @@ impl<'a> RenderContext<'a> {
     }
 
     /// Configures the maximum number of adjectives to evaluate for disambiguation combinations.
+    ///
+    /// The absolute maximum allowed value is 127 to prevent integer overflow during the
+    /// combinatorial search. If a larger value is provided, it will be clamped to 127
+    /// and a warning will be logged.
     #[must_use]
     pub fn with_adjective_disambiguation_limit(mut self, limit: usize) -> Self {
-        self.adjective_disambiguation_limit = limit;
+        let max_limit = (u128::BITS - 1) as usize;
+        if limit > max_limit {
+            tracing::warn!(
+                "Adjective disambiguation limit {} exceeds the maximum supported value of {}. Clamping to {}.",
+                limit,
+                max_limit,
+                max_limit
+            );
+            self.adjective_disambiguation_limit = max_limit;
+        } else {
+            self.adjective_disambiguation_limit = limit;
+        }
         self
     }
 
@@ -880,6 +1006,7 @@ impl<'a> RenderContext<'a> {
                     gender: entity.gender(),
                     flags,
                     adjectives: Vec::new(),
+                    resolved_name: None,
                 });
             }
 
@@ -927,6 +1054,15 @@ impl<'a> RenderContext<'a> {
     #[must_use]
     pub fn last_mentioned(&self) -> Option<String> {
         self.last_mentioned.borrow().clone()
+    }
+
+    /// Retrieves the key of the active grammatical subject in the current clause.
+    ///
+    /// This is automatically updated by the engine whenever a verb tag is processed
+    /// and represents the entity currently driving the narrative action.
+    #[must_use]
+    pub fn active_subject(&self) -> Option<String> {
+        self.active_subject.borrow().clone()
     }
 
     /// Clears the anaphora resolution memory, treating all subsequent entities as newly introduced.
@@ -977,6 +1113,7 @@ impl<'a> RenderContext<'a> {
                     gender: entity.gender(),
                     flags,
                     adjectives: Vec::new(),
+                    resolved_name: None,
                 });
             }
             let mut last_mentioned = self.last_mentioned.borrow_mut();
@@ -1149,10 +1286,10 @@ fn check_phrase_match(
             let valid_adjs = entity.adjectives().unwrap_or(&[]);
             let synonym_adjs = entity.adjective_synonyms().unwrap_or(&[]);
             adj_words.iter().all(|i_adj| {
-                valid_adjs
+                inline_adjectives
                     .iter()
                     .any(|v_adj| eq_ignore_case(i_adj, v_adj, strict_diacritics))
-                    || inline_adjectives
+                    || valid_adjs
                         .iter()
                         .any(|v_adj| eq_ignore_case(i_adj, v_adj, strict_diacritics))
                     || synonym_adjs

--- a/src/models.rs
+++ b/src/models.rs
@@ -130,6 +130,13 @@ pub trait TemplateEntity {
         None
     }
 
+    /// Returns an optional list of adjective synonyms for this entity.
+    /// Used by `RenderContext::resolve_target` to allow fuzzy matching (e.g., "big" for "large").
+    /// These are NOT used for rendering to avoid phrases like "the big large wolf".
+    fn adjective_synonyms(&self) -> Option<&[&str]> {
+        None
+    }
+
     /// Determines if the entity's current identity is a proper noun.
     ///
     /// If `true`, the rendering engine will automatically suppress indefinite (`a/an`)
@@ -198,6 +205,12 @@ pub struct RenderContext<'a> {
     /// Defaults to 15. Set to 0 for unbounded growth.
     /// If all entities in memory are pinned, this limit will be temporarily exceeded to preserve narrative continuity.
     pub anaphora_limit: usize,
+    /// The maximum number of adjectives to evaluate when generating combinations for disambiguation.
+    /// Capping this prevents exponential O(2^N) blowup if an entity has a large number of adjectives. Defaults to 5.
+    pub adjective_disambiguation_limit: usize,
+    /// If true, automatically clears the anaphora memory at the end of each successful render call.
+    /// Defaults to false.
+    pub auto_clear: bool,
     /// A mapping of template syntax keys (e.g., "source") to their actual game entities.
     /// Keys are normalized to lowercase by the engine, so ensure your builder mapping uses lowercase keys.
     pub entities: HashMap<&'a str, &'a dyn TemplateEntity>,
@@ -213,6 +226,8 @@ pub struct RenderContext<'a> {
     pub recent_entities: RefCell<Vec<RecentEntity>>,
     /// Tracks the assignment of ordinals for entities with colliding names.
     pub ordinals: RefCell<HashMap<String, OrdinalState>>,
+    /// A memoization cache for target resolution within the lifespan of this context.
+    pub(crate) target_cache: RefCell<HashMap<String, Vec<TargetMatch<'a>>>>,
 }
 
 bitflags::bitflags! {
@@ -325,11 +340,14 @@ impl<'a> RenderContext<'a> {
             ordinal_word_threshold: 999,
             strict_diacritics: false,
             anaphora_limit: 15,
+            adjective_disambiguation_limit: 5,
+            auto_clear: false,
             entities: HashMap::new(),
             last_mentioned: RefCell::new(None),
             active_subject: RefCell::new(None),
             recent_entities: RefCell::new(Vec::new()),
             ordinals: RefCell::new(HashMap::new()),
+            target_cache: RefCell::new(HashMap::new()),
         }
     }
 
@@ -345,6 +363,10 @@ impl<'a> RenderContext<'a> {
     /// `path_uncertain` will be `true`, allowing the caller to decide whether to accept it.
     #[must_use]
     pub fn resolve_target(&self, description: &str) -> Vec<TargetMatch<'a>> {
+        if let Some(cached) = self.target_cache.borrow().get(description) {
+            return cached.clone();
+        }
+
         let (base_desc, sub_element_desc) = parse_target_description(description);
 
         let clean_full_desc_owned = description.to_lowercase().replace('’', "'");
@@ -437,6 +459,9 @@ impl<'a> RenderContext<'a> {
             }
         }
 
+        self.target_cache
+            .borrow_mut()
+            .insert(description.to_string(), unique_matches.clone());
         unique_matches
     }
 
@@ -582,10 +607,11 @@ impl<'a> RenderContext<'a> {
         inline_adjectives: &[String],
     ) -> bool {
         let mut ords = Vec::new();
-        let suffix = format!("::{name_to_check}");
+        let suffix_ns = format!("::{name_to_check}");
+        let suffix_adj = format!(" {name_to_check}");
 
         for (k, state) in self.ordinals.borrow().iter() {
-            if (k == name_to_check || k.ends_with(&suffix))
+            if (k == name_to_check || k.ends_with(&suffix_ns) || k.ends_with(&suffix_adj))
                 && let Some(&o) = state.members.get(key)
                 && !ords.contains(&o)
             {
@@ -690,6 +716,7 @@ impl<'a> RenderContext<'a> {
     #[must_use]
     pub fn with_viewer(mut self, viewer_id: &'a str) -> Self {
         self.viewer_id = viewer_id;
+        self.target_cache.get_mut().clear();
         self
     }
 
@@ -697,6 +724,7 @@ impl<'a> RenderContext<'a> {
     #[must_use]
     pub fn with_stance(mut self, stance: ActorStance) -> Self {
         self.stance = stance;
+        self.target_cache.get_mut().clear();
         self
     }
 
@@ -720,6 +748,7 @@ impl<'a> RenderContext<'a> {
     #[must_use]
     pub fn with_ordinal_word_threshold(mut self, threshold: usize) -> Self {
         self.ordinal_word_threshold = threshold;
+        self.target_cache.get_mut().clear();
         self
     }
 
@@ -729,6 +758,7 @@ impl<'a> RenderContext<'a> {
     #[must_use]
     pub fn with_strict_diacritics(mut self, strict: bool) -> Self {
         self.strict_diacritics = strict;
+        self.target_cache.get_mut().clear();
         self
     }
 
@@ -740,6 +770,22 @@ impl<'a> RenderContext<'a> {
         self
     }
 
+    /// Configures the maximum number of adjectives to evaluate for disambiguation combinations.
+    #[must_use]
+    pub fn with_adjective_disambiguation_limit(mut self, limit: usize) -> Self {
+        self.adjective_disambiguation_limit = limit;
+        self
+    }
+
+    /// Enables or disables automatic clearing of anaphora memory after rendering.
+    /// If `true`, the context will automatically call `clear_anaphora()` at the end of every `PerspectiveEngine::render` call,
+    /// ensuring each render starts with a fresh narrative memory.
+    #[must_use]
+    pub fn with_auto_clear(mut self, auto_clear: bool) -> Self {
+        self.auto_clear = auto_clear;
+        self
+    }
+
     /// Adds an entity mapping to the context using a fluent builder pattern.
     ///
     /// # Arguments
@@ -748,6 +794,7 @@ impl<'a> RenderContext<'a> {
     #[must_use]
     pub fn with_entity(mut self, key: &'a str, entity: &'a dyn TemplateEntity) -> Self {
         self.entities.insert(key, entity);
+        self.target_cache.get_mut().clear();
         self
     }
 
@@ -823,6 +870,7 @@ impl<'a> RenderContext<'a> {
                 &mut last_mentioned,
                 &mut active_subject,
             );
+            self.target_cache.borrow_mut().clear();
         }
         self
     }
@@ -846,6 +894,7 @@ impl<'a> RenderContext<'a> {
         *self.active_subject.borrow_mut() = state.active_subject;
         *self.recent_entities.borrow_mut() = state.recent_entities;
         *self.ordinals.borrow_mut() = state.ordinals;
+        self.target_cache.borrow_mut().clear();
         self
     }
 
@@ -864,6 +913,7 @@ impl<'a> RenderContext<'a> {
         *self.active_subject.borrow_mut() = None;
         self.recent_entities.borrow_mut().clear();
         self.ordinals.borrow_mut().clear();
+        self.target_cache.borrow_mut().clear();
     }
 
     /// Pins an entity in the anaphora memory so it will never be automatically evicted.
@@ -915,6 +965,7 @@ impl<'a> RenderContext<'a> {
                 &mut last_mentioned,
                 &mut active_subject,
             );
+            self.target_cache.borrow_mut().clear();
         }
     }
 
@@ -927,6 +978,7 @@ impl<'a> RenderContext<'a> {
             .find(|r| r.key == key)
         {
             item.flags.remove(RecentEntityFlags::IS_PINNED);
+            self.target_cache.borrow_mut().clear();
         }
     }
 
@@ -939,6 +991,18 @@ impl<'a> RenderContext<'a> {
             *self.active_subject.borrow_mut() = None;
         }
         self.recent_entities.borrow_mut().retain(|r| r.key != key);
+        self.target_cache.borrow_mut().clear();
+    }
+
+    /// Explicitly clears the memoization cache used by `resolve_target`.
+    ///
+    /// You normally do not need to call this, as the engine automatically invalidates the cache
+    /// whenever the context's state (such as anaphora memory, ordinals, or stances) changes.
+    /// However, if you mutate an entity's internal data (like its name or adjectives) using
+    /// interior mutability while the `RenderContext` is still active, you should call this
+    /// method to ensure subsequent target resolutions reflect the updated data.
+    pub fn clear_target_cache(&self) {
+        self.target_cache.borrow_mut().clear();
     }
 }
 
@@ -1061,11 +1125,15 @@ fn check_phrase_match(
     let validate_adjectives = |adj_words: &[&str]| -> bool {
         adj_words.is_empty() || {
             let valid_adjs = entity.adjectives().unwrap_or(&[]);
+            let synonym_adjs = entity.adjective_synonyms().unwrap_or(&[]);
             adj_words.iter().all(|i_adj| {
                 valid_adjs
                     .iter()
                     .any(|v_adj| eq_ignore_case(i_adj, v_adj, strict_diacritics))
                     || inline_adjectives
+                        .iter()
+                        .any(|v_adj| eq_ignore_case(i_adj, v_adj, strict_diacritics))
+                    || synonym_adjs
                         .iter()
                         .any(|v_adj| eq_ignore_case(i_adj, v_adj, strict_diacritics))
             })

--- a/src/models.rs
+++ b/src/models.rs
@@ -711,20 +711,45 @@ impl<'a> RenderContext<'a> {
         false
     }
 
+    // --- Private Setters for Cache Invalidation ---
+
+    fn set_viewer_id(&mut self, viewer_id: &'a str) {
+        self.viewer_id = viewer_id;
+        self.clear_target_cache();
+    }
+
+    fn set_stance(&mut self, stance: ActorStance) {
+        self.stance = stance;
+        self.clear_target_cache();
+    }
+
+    fn set_ordinal_word_threshold(&mut self, threshold: usize) {
+        self.ordinal_word_threshold = threshold;
+        self.clear_target_cache();
+    }
+
+    fn set_strict_diacritics(&mut self, strict: bool) {
+        self.strict_diacritics = strict;
+        self.clear_target_cache();
+    }
+
+    fn add_entity(&mut self, key: &'a str, entity: &'a dyn TemplateEntity) {
+        self.entities.insert(key, entity);
+        self.clear_target_cache();
+    }
+
     /// Configures the viewer ID for the rendering context.
     /// This is particularly useful when cloning a base context to render the same event for multiple observers.
     #[must_use]
     pub fn with_viewer(mut self, viewer_id: &'a str) -> Self {
-        self.viewer_id = viewer_id;
-        self.clear_target_cache();
+        self.set_viewer_id(viewer_id);
         self
     }
 
     /// Configures the actor stance for the rendering context.
     #[must_use]
     pub fn with_stance(mut self, stance: ActorStance) -> Self {
-        self.stance = stance;
-        self.clear_target_cache();
+        self.set_stance(stance);
         self
     }
 
@@ -747,8 +772,7 @@ impl<'a> RenderContext<'a> {
     /// Defaults to 999. Set to 0 to always use integer form.
     #[must_use]
     pub fn with_ordinal_word_threshold(mut self, threshold: usize) -> Self {
-        self.ordinal_word_threshold = threshold;
-        self.clear_target_cache();
+        self.set_ordinal_word_threshold(threshold);
         self
     }
 
@@ -757,8 +781,7 @@ impl<'a> RenderContext<'a> {
     /// If `false` (default), the engine transliterates Unicode to ASCII for fuzzy matching (e.g., "Ängry" matches "angry").
     #[must_use]
     pub fn with_strict_diacritics(mut self, strict: bool) -> Self {
-        self.strict_diacritics = strict;
-        self.clear_target_cache();
+        self.set_strict_diacritics(strict);
         self
     }
 
@@ -793,8 +816,7 @@ impl<'a> RenderContext<'a> {
     /// * `entity` - A reference to the game object implementing `TemplateEntity`.
     #[must_use]
     pub fn with_entity(mut self, key: &'a str, entity: &'a dyn TemplateEntity) -> Self {
-        self.entities.insert(key, entity);
-        self.clear_target_cache();
+        self.add_entity(key, entity);
         self
     }
 

--- a/src/models.rs
+++ b/src/models.rs
@@ -716,7 +716,7 @@ impl<'a> RenderContext<'a> {
     #[must_use]
     pub fn with_viewer(mut self, viewer_id: &'a str) -> Self {
         self.viewer_id = viewer_id;
-        self.target_cache.get_mut().clear();
+        self.clear_target_cache();
         self
     }
 
@@ -724,7 +724,7 @@ impl<'a> RenderContext<'a> {
     #[must_use]
     pub fn with_stance(mut self, stance: ActorStance) -> Self {
         self.stance = stance;
-        self.target_cache.get_mut().clear();
+        self.clear_target_cache();
         self
     }
 
@@ -748,7 +748,7 @@ impl<'a> RenderContext<'a> {
     #[must_use]
     pub fn with_ordinal_word_threshold(mut self, threshold: usize) -> Self {
         self.ordinal_word_threshold = threshold;
-        self.target_cache.get_mut().clear();
+        self.clear_target_cache();
         self
     }
 
@@ -758,7 +758,7 @@ impl<'a> RenderContext<'a> {
     #[must_use]
     pub fn with_strict_diacritics(mut self, strict: bool) -> Self {
         self.strict_diacritics = strict;
-        self.target_cache.get_mut().clear();
+        self.clear_target_cache();
         self
     }
 
@@ -794,7 +794,7 @@ impl<'a> RenderContext<'a> {
     #[must_use]
     pub fn with_entity(mut self, key: &'a str, entity: &'a dyn TemplateEntity) -> Self {
         self.entities.insert(key, entity);
-        self.target_cache.get_mut().clear();
+        self.clear_target_cache();
         self
     }
 
@@ -870,7 +870,7 @@ impl<'a> RenderContext<'a> {
                 &mut last_mentioned,
                 &mut active_subject,
             );
-            self.target_cache.borrow_mut().clear();
+            self.clear_target_cache();
         }
         self
     }
@@ -894,7 +894,7 @@ impl<'a> RenderContext<'a> {
         *self.active_subject.borrow_mut() = state.active_subject;
         *self.recent_entities.borrow_mut() = state.recent_entities;
         *self.ordinals.borrow_mut() = state.ordinals;
-        self.target_cache.borrow_mut().clear();
+        self.clear_target_cache();
         self
     }
 
@@ -913,7 +913,7 @@ impl<'a> RenderContext<'a> {
         *self.active_subject.borrow_mut() = None;
         self.recent_entities.borrow_mut().clear();
         self.ordinals.borrow_mut().clear();
-        self.target_cache.borrow_mut().clear();
+        self.clear_target_cache();
     }
 
     /// Pins an entity in the anaphora memory so it will never be automatically evicted.
@@ -965,7 +965,7 @@ impl<'a> RenderContext<'a> {
                 &mut last_mentioned,
                 &mut active_subject,
             );
-            self.target_cache.borrow_mut().clear();
+            self.clear_target_cache();
         }
     }
 
@@ -978,7 +978,7 @@ impl<'a> RenderContext<'a> {
             .find(|r| r.key == key)
         {
             item.flags.remove(RecentEntityFlags::IS_PINNED);
-            self.target_cache.borrow_mut().clear();
+            self.clear_target_cache();
         }
     }
 
@@ -991,7 +991,7 @@ impl<'a> RenderContext<'a> {
             *self.active_subject.borrow_mut() = None;
         }
         self.recent_entities.borrow_mut().retain(|r| r.key != key);
-        self.target_cache.borrow_mut().clear();
+        self.clear_target_cache();
     }
 
     /// Explicitly clears the memoization cache used by `resolve_target`.

--- a/src/models.rs
+++ b/src/models.rs
@@ -207,7 +207,7 @@ pub struct RenderContext<'a> {
     pub anaphora_limit: usize,
     /// The maximum number of adjectives to evaluate when generating combinations for disambiguation.
     /// Capping this prevents exponential O(2^N) blowup if an entity has a large number of adjectives. Defaults to 5.
-    /// The absolute mathematical maximum is 127 to prevent bitshift overflow.
+    /// The absolute mathematical maximum is 63 to prevent bitshift overflow.
     pub adjective_disambiguation_limit: usize,
     /// If true, automatically clears the anaphora memory at the end of each successful render call.
     /// Defaults to false.
@@ -906,12 +906,12 @@ impl<'a> RenderContext<'a> {
 
     /// Configures the maximum number of adjectives to evaluate for disambiguation combinations.
     ///
-    /// The absolute maximum allowed value is 127 to prevent integer overflow during the
-    /// combinatorial search. If a larger value is provided, it will be clamped to 127
+    /// The absolute maximum allowed value is 63 to prevent integer overflow during the
+    /// combinatorial search. If a larger value is provided, it will be clamped to 63
     /// and a warning will be logged.
     #[must_use]
     pub fn with_adjective_disambiguation_limit(mut self, limit: usize) -> Self {
-        let max_limit = (u128::BITS - 1) as usize;
+        let max_limit = (u64::BITS - 1) as usize;
         if limit > max_limit {
             tracing::warn!(
                 "Adjective disambiguation limit {} exceeds the maximum supported value of {}. Clamping to {}.",

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -217,21 +217,14 @@ impl Template {
             [p1, p2, p3] => {
                 let (p1_clean, _) = parse_stance_prefixes(p1);
                 if p1_clean.is_empty() || is_article(p1_clean) {
-                    let (p2_clean, _) = parse_stance_prefixes(p2);
                     let article = if p1.is_empty() { None } else { Some(*p1) };
 
-                    if is_owner_part(p2_clean) && !is_p_type(p3) {
-                        Ok((article, Some(*p2), *p3, None))
-                    } else if is_p_type(p3) || p3.is_empty() {
+                    if is_p_type(p3) || p3.is_empty() {
                         Ok((article, None, *p2, Some(*p3)))
                     } else {
-                        Err(validation_error(
-                            "Malformed entity tag",
-                            content,
-                            TAG_ENTITY_OPEN,
-                        ))
+                        Ok((article, Some(*p2), *p3, None))
                     }
-                } else if is_owner_part(p1_clean) && (is_p_type(p3) || p3.is_empty()) {
+                } else if is_p_type(p3) || p3.is_empty() {
                     Ok((None, Some(*p1), *p2, Some(*p3)))
                 } else {
                     Err(validation_error(
@@ -249,17 +242,11 @@ impl Template {
                     Ok((article, None, *p2, None))
                 } else if is_p_type(p2) || p2.is_empty() {
                     Ok((None, None, *p1, Some(*p2)))
-                } else if is_owner_part(p1_clean) {
-                    Ok((None, Some(*p1), *p2, None))
                 } else if p1_clean.is_empty() {
                     let article = if p1.is_empty() { None } else { Some(*p1) };
                     Ok((article, None, *p2, None))
                 } else {
-                    Err(validation_error(
-                        "Malformed entity tag",
-                        content,
-                        TAG_ENTITY_OPEN,
-                    ))
+                    Ok((None, Some(*p1), *p2, None))
                 }
             }
             [p1] => Ok((None, None, *p1, None)),
@@ -341,14 +328,16 @@ impl Template {
             {
                 (stripped, "")
             } else {
-                (owner_part, "")
+                ("", owner_part)
             };
 
-            let (clean_owner, mut o_flags) = parse_stance_prefixes(owner_str);
-            let clean_owner = clean_owner.trim();
-            o_flags.set(TagFlags::IS_CAPITALIZED, is_capitalized(clean_owner));
-            owner_key = Some(clean_owner.to_lowercase());
-            owner_flags = o_flags;
+            if !owner_str.is_empty() {
+                let (clean_owner, mut o_flags) = parse_stance_prefixes(owner_str);
+                let clean_owner = clean_owner.trim();
+                o_flags.set(TagFlags::IS_CAPITALIZED, is_capitalized(clean_owner));
+                owner_key = Some(clean_owner.to_lowercase());
+                owner_flags = o_flags;
+            }
 
             let adj = adj_str.trim();
             if !adj.is_empty() {
@@ -757,13 +746,6 @@ pub(crate) fn is_p_type(s: &str) -> bool {
         lower.as_str(),
         "subj" | "obj" | "poss" | "abs_poss" | "reflex"
     )
-}
-
-#[inline]
-pub(crate) fn is_owner_part(s: &str) -> bool {
-    let (clean, _) = parse_stance_prefixes(s);
-    let clean = clean.trim();
-    parse_possessive_suffix(clean).1 || find_spaced_possessive(clean).is_some()
 }
 
 #[inline]

--- a/src/tests/anaphora.rs
+++ b/src/tests/anaphora.rs
@@ -777,7 +777,7 @@ fn test_with_last_mentioned_preserves_pinned_status() {
     .expect("Failed to render template");
 
     // If `with_last_mentioned` accidentally cleared Bob's flags, he would have been evicted as the oldest.
-    // Because his IS_PINNED flag was preserved, Tom (the newest but unpinned) is instantly evicted instead!
+    // Because his IS_PINNED flag was preserved, Tom (the newest but unpinned) is evicted instead.
     assert_eq!(ctx.recent_entities.borrow()[0].key, "bob");
 }
 

--- a/src/tests/anaphora.rs
+++ b/src/tests/anaphora.rs
@@ -439,6 +439,7 @@ fn test_in_place_anaphora_mutations() {
     let ctx = RenderContext::new("viewer").with_entity("bob", &m1);
 
     let ctx = ctx.with_last_mentioned("bob");
+    assert!(!ctx.is_entity_pinned("bob"));
     assert!(
         !ctx.recent_entities
             .borrow()
@@ -449,6 +450,7 @@ fn test_in_place_anaphora_mutations() {
     );
 
     ctx.pin_anaphora("bob");
+    assert!(ctx.is_entity_pinned("bob"));
     assert!(
         ctx.recent_entities
             .borrow()
@@ -459,6 +461,7 @@ fn test_in_place_anaphora_mutations() {
     );
 
     ctx.unpin_anaphora("bob");
+    assert!(!ctx.is_entity_pinned("bob"));
     assert!(
         !ctx.recent_entities
             .borrow()
@@ -1243,4 +1246,71 @@ fn test_anaphora_dynamic_epistemological_mutation() {
         PerspectiveEngine::render(&t3, &ctx_disguised).unwrap(),
         "The tall man flees."
     );
+}
+
+#[test]
+fn test_active_subject_tracking() {
+    let player = MockEntity {
+        id: "char_1".to_string(),
+        name: "Aldran".to_string(),
+        gender: Gender::Male,
+        is_plural: false,
+        is_proper_noun: true,
+    };
+    let goblin = MockEntity {
+        id: "mob_1".to_string(),
+        name: "goblin".to_string(),
+        gender: Gender::Neutral,
+        is_plural: false,
+        is_proper_noun: false,
+    };
+
+    let cache = TemplateCache::new(100);
+    let ctx = RenderContext::new("char_2")
+        .with_entity("source", &player)
+        .with_entity("target", &goblin);
+
+    assert_eq!(ctx.active_subject(), None);
+
+    let t1 = cache
+        .get_or_compile("{*A:source:subj} [source:hit] {*the:target:obj}.")
+        .expect("Failed to compile template");
+    PerspectiveEngine::render(&t1, &ctx).expect("Failed to render template");
+
+    assert_eq!(ctx.active_subject().as_deref(), Some("source"));
+
+    let t2 = cache
+        .get_or_compile("{a:target:Subj} [target:retaliate]!")
+        .expect("Failed to compile template");
+    PerspectiveEngine::render(&t2, &ctx).expect("Failed to render template");
+
+    assert_eq!(ctx.active_subject().as_deref(), Some("target"));
+}
+
+#[test]
+fn test_has_seen_entity() {
+    let goblin = MockEntity {
+        id: "mob_1".to_string(),
+        name: "goblin".to_string(),
+        gender: Gender::Neutral,
+        is_plural: false,
+        is_proper_noun: false,
+    };
+
+    let cache = TemplateCache::new(100);
+    let ctx = RenderContext::new("viewer").with_entity("target", &goblin);
+
+    assert!(!ctx.has_seen_entity("target"));
+
+    let t = cache
+        .get_or_compile("{*A:target:subj} [target:arrive].")
+        .expect("Failed to compile template");
+    PerspectiveEngine::render(&t, &ctx).expect("Failed to render template");
+
+    assert!(ctx.has_seen_entity("target"));
+    assert!(ctx.extract_anaphora().has_seen_entity("target"));
+
+    ctx.clear_anaphora();
+
+    assert!(!ctx.has_seen_entity("target"));
 }

--- a/src/tests/descriptions.rs
+++ b/src/tests/descriptions.rs
@@ -890,11 +890,11 @@ fn test_adjective_disambiguation_limit() {
     };
     let w2 = AdjEntity {
         name: "wolf",
-        adjs: &["large", "red", "fluffy"],
+        adjs: &["large", "red", "feral", "fluffy"],
     };
     let w3 = AdjEntity {
         name: "wolf",
-        adjs: &["large", "red", "angry"],
+        adjs: &["large", "red", "feral", "angry"],
     };
 
     let cache = TemplateCache::new(100);
@@ -902,30 +902,29 @@ fn test_adjective_disambiguation_limit() {
         .get_or_compile("{*A:w1:subj}, {*a:w2:subj}, and {*a:w3:subj} arrive.")
         .expect("Failed to compile template");
 
-    // 1. With limit = 2
-    // All three wolves only evaluate combinations from `["large", "red"]`.
-    // Since they all share these two adjectives, they provide no disambiguation value,
-    // so they are dropped entirely, falling back to base names with ordinals.
-    let ctx_limit_2 = RenderContext::new("viewer")
+    // 1. With limit = 1
+    // "large" and "red" are shared by ALL wolves, so they are dropped completely and don't count towards the limit!
+    // w2 and w3 then evaluate their next adjective ("feral").
+    // Because limit = 1, they stop there. Since both share "feral", they collide and get ordinals.
+    let ctx_limit_1 = RenderContext::new("viewer")
         .with_entity("w1", &w1)
         .with_entity("w2", &w2)
         .with_entity("w3", &w3)
         .with_lookahead(true)
-        .with_adjective_disambiguation_limit(2)
+        .with_adjective_disambiguation_limit(1)
         .with_auto_clear(true);
 
     assert_eq!(
-        PerspectiveEngine::render(&t1, &ctx_limit_2).expect("Failed to render template"),
-        "A wolf, another wolf, and a third wolf arrive."
+        PerspectiveEngine::render(&t1, &ctx_limit_1).expect("Failed to render template"),
+        "A wolf, a feral wolf, and another feral wolf arrive."
     );
 
-    // 2. With limit = 3
-    // w2 and w3 can now evaluate their 3rd adjectives ("fluffy" and "angry"), which are unique!
-    // Because they vacate the collision group, w1 is left as the only "wolf".
-    let ctx_limit_3 = ctx_limit_2.with_adjective_disambiguation_limit(3);
+    // 2. With limit = 2
+    // w2 and w3 can now evaluate their next adjectives ("fluffy" and "angry"), which are unique!
+    let ctx_limit_2 = ctx_limit_1.with_adjective_disambiguation_limit(2);
 
     assert_eq!(
-        PerspectiveEngine::render(&t1, &ctx_limit_3).expect("Failed to render template"),
+        PerspectiveEngine::render(&t1, &ctx_limit_2).expect("Failed to render template"),
         "A wolf, a fluffy wolf, and an angry wolf arrive."
     );
 
@@ -949,12 +948,71 @@ fn test_adjective_disambiguation_limit() {
         .expect("Failed to compile template");
 
     // w4 evaluates `fluffy` and `white`.
-    // Even though w5's limit is 2 (so it only searches `large` and `black` for itself),
-    // w4 checking w5 for uniqueness correctly sees w5's 3rd adjective `fluffy`.
-    // Thus, w4 realizes `fluffy` is not unique, and correctly chooses `white`!
+    // Because `fluffy` is shared by all colliders (w5), it is dropped before the limit is enforced!
+    // w4 then safely evaluates `white` and succeeds, proving that it can see w5's 3rd adjective
+    // during the shared-filtering pass, even though w5's own limit is 2.
     assert_eq!(
         PerspectiveEngine::render(&t2, &ctx_check_all).expect("Failed to render template"),
         "A white wolf and a large wolf stare."
+    );
+}
+
+#[test]
+fn test_adjective_disambiguation_limit_clamping() {
+    struct AdjEntity {
+        name: &'static str,
+        adjs: &'static [&'static str],
+    }
+    impl TemplateEntity for AdjEntity {
+        fn contains_viewer(&self, _: &str) -> bool {
+            false
+        }
+        fn gender(&self) -> Gender {
+            Gender::Neutral
+        }
+        fn is_plural(&self) -> bool {
+            false
+        }
+        fn is_proper_noun_for(&self, _: &str) -> bool {
+            false
+        }
+        fn display_name_for<'a>(&'a self, _: &str) -> Cow<'a, str> {
+            Cow::Borrowed(self.name)
+        }
+        fn adjectives(&self) -> Option<&[&str]> {
+            Some(self.adjs)
+        }
+    }
+
+    let w1 = AdjEntity {
+        name: "wolf",
+        adjs: &["large", "red"],
+    };
+    let w2 = AdjEntity {
+        name: "wolf",
+        adjs: &["large", "brown"],
+    };
+
+    // 1. Verify clamping to 127 prevents overflow
+    let ctx_clamped = RenderContext::new("viewer").with_adjective_disambiguation_limit(200);
+    assert_eq!(ctx_clamped.adjective_disambiguation_limit, 127);
+
+    // 2. Verify setting the limit to 0 safely completely disables adjective disambiguation
+    // and falls back natively to ordinals.
+    let cache = TemplateCache::new(100);
+    let t = cache
+        .get_or_compile("{*A:w1:subj} and {*a:w2:subj} arrive.")
+        .expect("Failed to compile template");
+
+    let ctx_zero = RenderContext::new("viewer")
+        .with_entity("w1", &w1)
+        .with_entity("w2", &w2)
+        .with_lookahead(true)
+        .with_adjective_disambiguation_limit(0);
+
+    assert_eq!(
+        PerspectiveEngine::render(&t, &ctx_zero).expect("Failed to render template"),
+        "A wolf and another wolf arrive."
     );
 }
 
@@ -1540,5 +1598,128 @@ fn test_no_smart_modifier_bypasses_ordinals() {
     assert_eq!(
         PerspectiveEngine::render(&t2, &ctx).expect("Failed to render template"),
         "The wolf howls."
+    );
+}
+
+#[test]
+fn test_latest_name_tracking() {
+    let wolf1 = MockEntity {
+        id: "mob_1".into(),
+        name: "wolf".into(),
+        gender: Gender::Neutral,
+        is_plural: false,
+        is_proper_noun: false,
+    };
+    let wolf2 = ConfigurableMockEntity {
+        id: "mob_2".into(),
+        name: "wolf".into(),
+        long_name: Some("large wolf".into()),
+        gender: Gender::Neutral,
+    };
+
+    let cache = TemplateCache::new(100);
+    let ctx = RenderContext::new("viewer")
+        .with_entity("w1", &wolf1)
+        .with_entity("w2", &wolf2);
+
+    let t = cache
+        .get_or_compile("{*A:w1:subj} and {*a:w2:subj} arrive. {a:w1:Subj} [w1:howl].")
+        .expect("Failed to compile template");
+    PerspectiveEngine::render(&t, &ctx).expect("Failed to render template");
+
+    // Ensure the tracked latest name matches the fully disambiguated string, and survives pronoun mentions.
+    assert_eq!(ctx.latest_name("w1").as_deref(), Some("wolf"));
+    assert_eq!(ctx.latest_name("w2").as_deref(), Some("large wolf"));
+
+    let state = ctx.extract_anaphora();
+    assert_eq!(state.latest_name("w1"), Some("wolf"));
+    assert_eq!(state.latest_name("w2"), Some("large wolf"));
+    assert_eq!(state.latest_name("missing"), None);
+}
+
+#[test]
+fn test_latest_name_eviction() {
+    let wolf = MockEntity {
+        id: "mob_1".into(),
+        name: "wolf".into(),
+        gender: Gender::Neutral,
+        is_plural: false,
+        is_proper_noun: false,
+    };
+    let orc = MockEntity {
+        id: "mob_2".into(),
+        name: "orc".into(),
+        gender: Gender::Neutral,
+        is_plural: false,
+        is_proper_noun: false,
+    };
+
+    let cache = TemplateCache::new(100);
+    let ctx = RenderContext::new("viewer")
+        .with_anaphora_limit(1) // Strict limit of 1
+        .with_entity("wolf", &wolf)
+        .with_entity("orc", &orc);
+
+    let t1 = cache
+        .get_or_compile("{*A:wolf:subj} enters.")
+        .expect("Failed to compile template");
+    PerspectiveEngine::render(&t1, &ctx).expect("Failed to render template");
+    assert_eq!(ctx.latest_name("wolf").as_deref(), Some("wolf"));
+
+    // Enter the orc. Because the limit is 1, the wolf gets evicted from memory.
+    let t2 = cache
+        .get_or_compile("{*An:orc:subj} enters.")
+        .expect("Failed to compile template");
+    PerspectiveEngine::render(&t2, &ctx).expect("Failed to render template");
+
+    // Verify that the tracked latest name is wiped along with the anaphora memory.
+    assert_eq!(ctx.latest_name("wolf"), None);
+    assert_eq!(ctx.latest_name("orc").as_deref(), Some("orc"));
+}
+
+#[test]
+fn test_state_tracking_ordinals_and_adjectives() {
+    let wolf1 = MockEntity {
+        id: "w1".into(),
+        name: "wolf".into(),
+        gender: Gender::Neutral,
+        is_plural: false,
+        is_proper_noun: false,
+    };
+    let wolf2 = MockEntity {
+        id: "w2".into(),
+        name: "wolf".into(),
+        gender: Gender::Neutral,
+        is_plural: false,
+        is_proper_noun: false,
+    };
+
+    let cache = TemplateCache::new(100);
+    let ctx = RenderContext::new("viewer")
+        .with_entity("w1", &wolf1)
+        .with_entity("w2", &wolf2)
+        .with_lookahead(true);
+
+    // Introduce an inline adjective and trigger ordinals
+    let t = cache
+        .get_or_compile("{*A:w1:subj} and {*A:angry:w2:subj} arrive.")
+        .expect("Failed to compile template");
+    PerspectiveEngine::render(&t, &ctx).expect("Failed to render template");
+
+    // 1. Verify `current_ordinal`
+    assert_eq!(ctx.current_ordinal("w1"), Some(1));
+    assert_eq!(ctx.current_ordinal("w2"), Some(2));
+    assert_eq!(ctx.current_ordinal("missing"), None);
+
+    // 2. Verify `inline_adjectives`
+    assert_eq!(ctx.inline_adjectives("w1"), Some(vec![]));
+    assert_eq!(ctx.inline_adjectives("w2"), Some(vec!["angry".to_string()]));
+
+    // 3. Verify it persists into the extracted `AnaphoraState`
+    let state = ctx.extract_anaphora();
+    assert_eq!(state.current_ordinal("w2"), Some(2));
+    assert_eq!(
+        state.inline_adjectives("w2"),
+        Some(&["angry".to_string()][..])
     );
 }

--- a/src/tests/descriptions.rs
+++ b/src/tests/descriptions.rs
@@ -993,9 +993,9 @@ fn test_adjective_disambiguation_limit_clamping() {
         adjs: &["large", "brown"],
     };
 
-    // 1. Verify clamping to 127 prevents overflow
+    // 1. Verify clamping to 63 prevents overflow
     let ctx_clamped = RenderContext::new("viewer").with_adjective_disambiguation_limit(200);
-    assert_eq!(ctx_clamped.adjective_disambiguation_limit, 127);
+    assert_eq!(ctx_clamped.adjective_disambiguation_limit, 63);
 
     // 2. Verify setting the limit to 0 safely completely disables adjective disambiguation
     // and falls back natively to ordinals.
@@ -1702,7 +1702,7 @@ fn test_state_tracking_ordinals_and_adjectives() {
 
     // Introduce an inline adjective and trigger ordinals
     let t = cache
-        .get_or_compile("{*A:w1:subj} and {*A:angry:w2:subj} arrive.")
+        .get_or_compile("{*A:w1:subj} and {*a:angry:w2:subj} arrive.")
         .expect("Failed to compile template");
     PerspectiveEngine::render(&t, &ctx).expect("Failed to render template");
 

--- a/src/tests/descriptions.rs
+++ b/src/tests/descriptions.rs
@@ -501,14 +501,14 @@ fn test_adjective_disambiguation() {
     let cache = TemplateCache::new(100);
     let t = cache
         .get_or_compile("{*A:w1:subj} and {*a:w2:subj} arrive.")
-        .unwrap();
+        .expect("Failed to compile template");
     let ctx = RenderContext::new("viewer")
         .with_entity("w1", &w1)
         .with_entity("w2", &w2)
         .with_lookahead(true);
 
     assert_eq!(
-        PerspectiveEngine::render(&t, &ctx).unwrap(),
+        PerspectiveEngine::render(&t, &ctx).expect("Failed to render template"),
         "A red wolf and a brown wolf arrive."
     );
 }
@@ -560,7 +560,7 @@ fn test_adjective_disambiguation_complex() {
     let cache = TemplateCache::new(100);
     let t = cache
         .get_or_compile("{*A:w1:subj}, {*a:w2:subj}, {*a:w3:subj}, and {*a:w4:subj} arrive.")
-        .unwrap();
+        .expect("Failed to compile template");
     let ctx = RenderContext::new("viewer")
         .with_entity("w1", &w1)
         .with_entity("w2", &w2)
@@ -569,7 +569,7 @@ fn test_adjective_disambiguation_complex() {
         .with_lookahead(true);
 
     assert_eq!(
-        PerspectiveEngine::render(&t, &ctx).unwrap(),
+        PerspectiveEngine::render(&t, &ctx).expect("Failed to render template"),
         "A grey large wolf, a large red wolf, a grey small wolf, and a red small wolf arrive."
     );
 }
@@ -617,7 +617,7 @@ fn test_adjective_disambiguation_partial_collision() {
     let cache = TemplateCache::new(100);
     let t1 = cache
         .get_or_compile("{*A:w1:subj}, {*a:w2:subj}, and {*a:w3:subj} arrive.")
-        .unwrap();
+        .expect("Failed to compile template");
     let ctx = RenderContext::new("viewer")
         .with_entity("w1", &w1)
         .with_entity("w2", &w2)
@@ -628,16 +628,16 @@ fn test_adjective_disambiguation_partial_collision() {
     // "red" distinguishes w1/w2 from w3, so it is used, but w1 and w2 still collide on "red",
     // receiving standard ordinals for the new "red wolf" group.
     assert_eq!(
-        PerspectiveEngine::render(&t1, &ctx).unwrap(),
+        PerspectiveEngine::render(&t1, &ctx).expect("Failed to render template"),
         "A red wolf, another red wolf, and a brown wolf arrive."
     );
 
     // Verify subsequent references use the ordinals correctly
     let t2 = cache
         .get_or_compile("{a:w1:Subj} [w1:howl]. {a:w2:Subj} [w2:growl]. {a:w3:Subj} [w3:bark].")
-        .unwrap();
+        .expect("Failed to compile template");
     assert_eq!(
-        PerspectiveEngine::render(&t2, &ctx).unwrap(),
+        PerspectiveEngine::render(&t2, &ctx).expect("Failed to render template"),
         "The first red wolf howls. The second red wolf growls. The brown wolf barks."
     );
 }
@@ -685,7 +685,7 @@ fn test_adjective_disambiguation_identical_with_plain_entity() {
     let cache = TemplateCache::new(100);
     let t1 = cache
         .get_or_compile("{*A:w1:subj}, {*a:w2:subj}, and {*a:w3:subj} arrive.")
-        .unwrap();
+        .expect("Failed to compile template");
     let ctx = RenderContext::new("viewer")
         .with_entity("w1", &w1)
         .with_entity("w2", &w2)
@@ -693,15 +693,15 @@ fn test_adjective_disambiguation_identical_with_plain_entity() {
         .with_lookahead(true);
 
     assert_eq!(
-        PerspectiveEngine::render(&t1, &ctx).unwrap(),
+        PerspectiveEngine::render(&t1, &ctx).expect("Failed to render template"),
         "A wolf, a large wolf, and another large wolf arrive."
     );
 
     let t2 = cache
         .get_or_compile("{*The:w1:subj} howls. {*The:w2:subj} growls. {*The:w3:subj} barks.")
-        .unwrap();
+        .expect("Failed to compile template");
     assert_eq!(
-        PerspectiveEngine::render(&t2, &ctx).unwrap(),
+        PerspectiveEngine::render(&t2, &ctx).expect("Failed to render template"),
         "The first wolf howls. The first large wolf growls. The second large wolf barks."
     );
 }
@@ -751,7 +751,7 @@ fn test_adjective_synonyms_ignored_for_disambiguation() {
     let cache = TemplateCache::new(100);
     let t = cache
         .get_or_compile("{*A:w1:subj} and {*a:w2:subj} arrive.")
-        .unwrap();
+        .expect("Failed to compile template");
     let ctx = RenderContext::new("viewer")
         .with_entity("w1", &w1)
         .with_entity("w2", &w2)
@@ -761,7 +761,7 @@ fn test_adjective_synonyms_ignored_for_disambiguation() {
     // disambiguation, completely ignoring the synonyms ("big", "tiny", etc.) to prevent
     // outputs like "A big wolf and a little wolf arrive."
     assert_eq!(
-        PerspectiveEngine::render(&t, &ctx).unwrap(),
+        PerspectiveEngine::render(&t, &ctx).expect("Failed to render template"),
         "A large wolf and a small wolf arrive."
     );
 }
@@ -900,7 +900,7 @@ fn test_adjective_disambiguation_limit() {
     let cache = TemplateCache::new(100);
     let t1 = cache
         .get_or_compile("{*A:w1:subj}, {*a:w2:subj}, and {*a:w3:subj} arrive.")
-        .unwrap();
+        .expect("Failed to compile template");
 
     // 1. With limit = 2
     // All three wolves only evaluate combinations from `["large", "red"]`.
@@ -915,7 +915,7 @@ fn test_adjective_disambiguation_limit() {
         .with_auto_clear(true);
 
     assert_eq!(
-        PerspectiveEngine::render(&t1, &ctx_limit_2).unwrap(),
+        PerspectiveEngine::render(&t1, &ctx_limit_2).expect("Failed to render template"),
         "A wolf, another wolf, and a third wolf arrive."
     );
 
@@ -925,7 +925,7 @@ fn test_adjective_disambiguation_limit() {
     let ctx_limit_3 = ctx_limit_2.with_adjective_disambiguation_limit(3);
 
     assert_eq!(
-        PerspectiveEngine::render(&t1, &ctx_limit_3).unwrap(),
+        PerspectiveEngine::render(&t1, &ctx_limit_3).expect("Failed to render template"),
         "A wolf, a fluffy wolf, and an angry wolf arrive."
     );
 
@@ -946,14 +946,14 @@ fn test_adjective_disambiguation_limit() {
         .with_adjective_disambiguation_limit(2);
     let t2 = cache
         .get_or_compile("{*A:w4:subj} and {*a:w5:subj} stare.")
-        .unwrap();
+        .expect("Failed to compile template");
 
     // w4 evaluates `fluffy` and `white`.
     // Even though w5's limit is 2 (so it only searches `large` and `black` for itself),
     // w4 checking w5 for uniqueness correctly sees w5's 3rd adjective `fluffy`.
     // Thus, w4 realizes `fluffy` is not unique, and correctly chooses `white`!
     assert_eq!(
-        PerspectiveEngine::render(&t2, &ctx_check_all).unwrap(),
+        PerspectiveEngine::render(&t2, &ctx_check_all).expect("Failed to render template"),
         "A white wolf and a large wolf stare."
     );
 }

--- a/src/tests/descriptions.rs
+++ b/src/tests/descriptions.rs
@@ -463,6 +463,310 @@ fn test_long_description_disambiguation_collision() {
 }
 
 #[test]
+fn test_adjective_disambiguation() {
+    struct AdjEntity {
+        name: &'static str,
+        adjs: &'static [&'static str],
+    }
+    impl TemplateEntity for AdjEntity {
+        fn contains_viewer(&self, _: &str) -> bool {
+            false
+        }
+        fn gender(&self) -> Gender {
+            Gender::Neutral
+        }
+        fn is_plural(&self) -> bool {
+            false
+        }
+        fn is_proper_noun_for(&self, _: &str) -> bool {
+            false
+        }
+        fn display_name_for<'a>(&'a self, _: &str) -> Cow<'a, str> {
+            Cow::Borrowed(self.name)
+        }
+        fn adjectives(&self) -> Option<&[&str]> {
+            Some(self.adjs)
+        }
+    }
+
+    let w1 = AdjEntity {
+        name: "wolf",
+        adjs: &["large", "red"],
+    };
+    let w2 = AdjEntity {
+        name: "wolf",
+        adjs: &["large", "brown"],
+    };
+
+    let cache = TemplateCache::new(100);
+    let t = cache
+        .get_or_compile("{*A:w1:subj} and {*a:w2:subj} arrive.")
+        .unwrap();
+    let ctx = RenderContext::new("viewer")
+        .with_entity("w1", &w1)
+        .with_entity("w2", &w2)
+        .with_lookahead(true);
+
+    assert_eq!(
+        PerspectiveEngine::render(&t, &ctx).unwrap(),
+        "A red wolf and a brown wolf arrive."
+    );
+}
+
+#[test]
+fn test_adjective_disambiguation_complex() {
+    struct AdjEntity {
+        name: &'static str,
+        adjs: &'static [&'static str],
+    }
+    impl TemplateEntity for AdjEntity {
+        fn contains_viewer(&self, _: &str) -> bool {
+            false
+        }
+        fn gender(&self) -> Gender {
+            Gender::Neutral
+        }
+        fn is_plural(&self) -> bool {
+            false
+        }
+        fn is_proper_noun_for(&self, _: &str) -> bool {
+            false
+        }
+        fn display_name_for<'a>(&'a self, _: &str) -> Cow<'a, str> {
+            Cow::Borrowed(self.name)
+        }
+        fn adjectives(&self) -> Option<&[&str]> {
+            Some(self.adjs)
+        }
+    }
+
+    let w1 = AdjEntity {
+        name: "wolf",
+        adjs: &["fierce", "large", "grey"],
+    };
+    let w2 = AdjEntity {
+        name: "wolf",
+        adjs: &["fierce", "large", "red"],
+    };
+    let w3 = AdjEntity {
+        name: "wolf",
+        adjs: &["fierce", "small", "grey"],
+    };
+    let w4 = AdjEntity {
+        name: "wolf",
+        adjs: &["fierce", "small", "red"],
+    };
+
+    let cache = TemplateCache::new(100);
+    let t = cache
+        .get_or_compile("{*A:w1:subj}, {*a:w2:subj}, {*a:w3:subj}, and {*a:w4:subj} arrive.")
+        .unwrap();
+    let ctx = RenderContext::new("viewer")
+        .with_entity("w1", &w1)
+        .with_entity("w2", &w2)
+        .with_entity("w3", &w3)
+        .with_entity("w4", &w4)
+        .with_lookahead(true);
+
+    assert_eq!(
+        PerspectiveEngine::render(&t, &ctx).unwrap(),
+        "A grey large wolf, a large red wolf, a grey small wolf, and a red small wolf arrive."
+    );
+}
+
+#[test]
+fn test_adjective_disambiguation_partial_collision() {
+    struct AdjEntity {
+        name: &'static str,
+        adjs: &'static [&'static str],
+    }
+    impl TemplateEntity for AdjEntity {
+        fn contains_viewer(&self, _: &str) -> bool {
+            false
+        }
+        fn gender(&self) -> Gender {
+            Gender::Neutral
+        }
+        fn is_plural(&self) -> bool {
+            false
+        }
+        fn is_proper_noun_for(&self, _: &str) -> bool {
+            false
+        }
+        fn display_name_for<'a>(&'a self, _: &str) -> Cow<'a, str> {
+            Cow::Borrowed(self.name)
+        }
+        fn adjectives(&self) -> Option<&[&str]> {
+            Some(self.adjs)
+        }
+    }
+
+    let w1 = AdjEntity {
+        name: "wolf",
+        adjs: &["large", "red"],
+    };
+    let w2 = AdjEntity {
+        name: "wolf",
+        adjs: &["large", "red"], // Identical to w1!
+    };
+    let w3 = AdjEntity {
+        name: "wolf",
+        adjs: &["large", "brown"],
+    };
+
+    let cache = TemplateCache::new(100);
+    let t1 = cache
+        .get_or_compile("{*A:w1:subj}, {*a:w2:subj}, and {*a:w3:subj} arrive.")
+        .unwrap();
+    let ctx = RenderContext::new("viewer")
+        .with_entity("w1", &w1)
+        .with_entity("w2", &w2)
+        .with_entity("w3", &w3)
+        .with_lookahead(true);
+
+    // "large" is shared by all 3, so it provides no disambiguation value and is dropped.
+    // "red" distinguishes w1/w2 from w3, so it is used, but w1 and w2 still collide on "red",
+    // receiving standard ordinals for the new "red wolf" group.
+    assert_eq!(
+        PerspectiveEngine::render(&t1, &ctx).unwrap(),
+        "A red wolf, another red wolf, and a brown wolf arrive."
+    );
+
+    // Verify subsequent references use the ordinals correctly
+    let t2 = cache
+        .get_or_compile("{a:w1:Subj} [w1:howl]. {a:w2:Subj} [w2:growl]. {a:w3:Subj} [w3:bark].")
+        .unwrap();
+    assert_eq!(
+        PerspectiveEngine::render(&t2, &ctx).unwrap(),
+        "The first red wolf howls. The second red wolf growls. The brown wolf barks."
+    );
+}
+
+#[test]
+fn test_adjective_disambiguation_identical_with_plain_entity() {
+    struct AdjEntity {
+        name: &'static str,
+        adjs: &'static [&'static str],
+    }
+    impl TemplateEntity for AdjEntity {
+        fn contains_viewer(&self, _: &str) -> bool {
+            false
+        }
+        fn gender(&self) -> Gender {
+            Gender::Neutral
+        }
+        fn is_plural(&self) -> bool {
+            false
+        }
+        fn is_proper_noun_for(&self, _: &str) -> bool {
+            false
+        }
+        fn display_name_for<'a>(&'a self, _: &str) -> Cow<'a, str> {
+            Cow::Borrowed(self.name)
+        }
+        fn adjectives(&self) -> Option<&[&str]> {
+            Some(self.adjs)
+        }
+    }
+
+    let w1 = AdjEntity {
+        name: "wolf",
+        adjs: &[],
+    };
+    let w2 = AdjEntity {
+        name: "wolf",
+        adjs: &["large"],
+    };
+    let w3 = AdjEntity {
+        name: "wolf",
+        adjs: &["large"],
+    };
+
+    let cache = TemplateCache::new(100);
+    let t1 = cache
+        .get_or_compile("{*A:w1:subj}, {*a:w2:subj}, and {*a:w3:subj} arrive.")
+        .unwrap();
+    let ctx = RenderContext::new("viewer")
+        .with_entity("w1", &w1)
+        .with_entity("w2", &w2)
+        .with_entity("w3", &w3)
+        .with_lookahead(true);
+
+    assert_eq!(
+        PerspectiveEngine::render(&t1, &ctx).unwrap(),
+        "A wolf, a large wolf, and another large wolf arrive."
+    );
+
+    let t2 = cache
+        .get_or_compile("{*The:w1:subj} howls. {*The:w2:subj} growls. {*The:w3:subj} barks.")
+        .unwrap();
+    assert_eq!(
+        PerspectiveEngine::render(&t2, &ctx).unwrap(),
+        "The first wolf howls. The first large wolf growls. The second large wolf barks."
+    );
+}
+
+#[test]
+fn test_adjective_synonyms_ignored_for_disambiguation() {
+    struct SynEntity {
+        name: &'static str,
+        adjs: &'static [&'static str],
+        syns: &'static [&'static str],
+    }
+    impl TemplateEntity for SynEntity {
+        fn contains_viewer(&self, _: &str) -> bool {
+            false
+        }
+        fn gender(&self) -> Gender {
+            Gender::Neutral
+        }
+        fn is_plural(&self) -> bool {
+            false
+        }
+        fn is_proper_noun_for(&self, _: &str) -> bool {
+            false
+        }
+        fn display_name_for<'a>(&'a self, _: &str) -> Cow<'a, str> {
+            Cow::Borrowed(self.name)
+        }
+        fn adjectives(&self) -> Option<&[&str]> {
+            Some(self.adjs)
+        }
+        fn adjective_synonyms(&self) -> Option<&[&str]> {
+            Some(self.syns)
+        }
+    }
+
+    let w1 = SynEntity {
+        name: "wolf",
+        adjs: &["large"],
+        syns: &["big", "huge"],
+    };
+    let w2 = SynEntity {
+        name: "wolf",
+        adjs: &["small"],
+        syns: &["tiny", "little"],
+    };
+
+    let cache = TemplateCache::new(100);
+    let t = cache
+        .get_or_compile("{*A:w1:subj} and {*a:w2:subj} arrive.")
+        .unwrap();
+    let ctx = RenderContext::new("viewer")
+        .with_entity("w1", &w1)
+        .with_entity("w2", &w2)
+        .with_lookahead(true);
+
+    // The engine should strictly use the canonical adjectives ("large", "small") for
+    // disambiguation, completely ignoring the synonyms ("big", "tiny", etc.) to prevent
+    // outputs like "A big wolf and a little wolf arrive."
+    assert_eq!(
+        PerspectiveEngine::render(&t, &ctx).unwrap(),
+        "A large wolf and a small wolf arrive."
+    );
+}
+
+#[test]
 fn test_long_description_partial_disambiguation() {
     let wolf_scrawny = MockEntity {
         id: "mob_1_scrawny".to_string(),
@@ -550,6 +854,107 @@ fn test_long_description_phantom_collision() {
     assert_eq!(
         PerspectiveEngine::render(&t1, &ctx1).expect("Failed to render template"),
         "Jim enters. A wolf enters. A large wolf enters. Another large wolf enters."
+    );
+}
+
+#[test]
+fn test_adjective_disambiguation_limit() {
+    struct AdjEntity {
+        name: &'static str,
+        adjs: &'static [&'static str],
+    }
+    impl TemplateEntity for AdjEntity {
+        fn contains_viewer(&self, _: &str) -> bool {
+            false
+        }
+        fn gender(&self) -> Gender {
+            Gender::Neutral
+        }
+        fn is_plural(&self) -> bool {
+            false
+        }
+        fn is_proper_noun_for(&self, _: &str) -> bool {
+            false
+        }
+        fn display_name_for<'a>(&'a self, _: &str) -> Cow<'a, str> {
+            Cow::Borrowed(self.name)
+        }
+        fn adjectives(&self) -> Option<&[&str]> {
+            Some(self.adjs)
+        }
+    }
+
+    let w1 = AdjEntity {
+        name: "wolf",
+        adjs: &["large", "red"],
+    };
+    let w2 = AdjEntity {
+        name: "wolf",
+        adjs: &["large", "red", "fluffy"],
+    };
+    let w3 = AdjEntity {
+        name: "wolf",
+        adjs: &["large", "red", "angry"],
+    };
+
+    let cache = TemplateCache::new(100);
+    let t1 = cache
+        .get_or_compile("{*A:w1:subj}, {*a:w2:subj}, and {*a:w3:subj} arrive.")
+        .unwrap();
+
+    // 1. With limit = 2
+    // All three wolves only evaluate combinations from `["large", "red"]`.
+    // Since they all share these two adjectives, they provide no disambiguation value,
+    // so they are dropped entirely, falling back to base names with ordinals.
+    let ctx_limit_2 = RenderContext::new("viewer")
+        .with_entity("w1", &w1)
+        .with_entity("w2", &w2)
+        .with_entity("w3", &w3)
+        .with_lookahead(true)
+        .with_adjective_disambiguation_limit(2)
+        .with_auto_clear(true);
+
+    assert_eq!(
+        PerspectiveEngine::render(&t1, &ctx_limit_2).unwrap(),
+        "A wolf, another wolf, and a third wolf arrive."
+    );
+
+    // 2. With limit = 3
+    // w2 and w3 can now evaluate their 3rd adjectives ("fluffy" and "angry"), which are unique!
+    // Because they vacate the collision group, w1 is left as the only "wolf".
+    let ctx_limit_3 = ctx_limit_2.with_adjective_disambiguation_limit(3);
+
+    assert_eq!(
+        PerspectiveEngine::render(&t1, &ctx_limit_3).unwrap(),
+        "A wolf, a fluffy wolf, and an angry wolf arrive."
+    );
+
+    // 3. Verify uniqueness checks ALL adjectives of colliders, regardless of limit
+    let w4 = AdjEntity {
+        name: "wolf",
+        adjs: &["fluffy", "white"],
+    };
+    let w5 = AdjEntity {
+        name: "wolf",
+        adjs: &["large", "black", "fluffy"],
+    };
+
+    let ctx_check_all = RenderContext::new("viewer")
+        .with_entity("w4", &w4)
+        .with_entity("w5", &w5)
+        .with_lookahead(true)
+        .with_adjective_disambiguation_limit(2);
+    let t2 = cache
+        .get_or_compile("{*A:w4:subj} and {*a:w5:subj} stare.")
+        .unwrap();
+
+    // w4 evaluates `fluffy` and `white`.
+    // Even though w5's limit is 2 (so it only searches `large` and `black` for itself),
+    // w4 checking w5 for uniqueness correctly sees w5's 3rd adjective `fluffy`.
+    // Thus, w4 realizes `fluffy` is not unique, and correctly chooses `white`!
+    assert_eq!(
+        PerspectiveEngine::render(&t2, &ctx_check_all).unwrap(),
+        "A white wolf and a large wolf stare."
     );
 }
 

--- a/src/tests/modifiers.rs
+++ b/src/tests/modifiers.rs
@@ -573,13 +573,13 @@ fn test_drop_possessive_override() {
         "I wield Excalibur."
     );
 
-    // 5. With adjectives -> Drops possessive and adjectives entirely
+    // 5. With adjectives -> Drops possessive but preserves adjectives
     let t3 = cache
         .get_or_compile("{*A:source:subj} [source:wield] {source's gleaming @excalibur}.")
         .expect("Failed to compile template");
     assert_eq!(
         PerspectiveEngine::render(&t3, &ctx).expect("Failed to render template"),
-        "Aldran wields Excalibur."
+        "Aldran wields gleaming Excalibur."
     );
 }
 

--- a/src/tests/parser.rs
+++ b/src/tests/parser.rs
@@ -2,6 +2,7 @@ use super::common::MockEntity;
 use crate::cache::TemplateCache;
 use crate::engine::{PerspectiveEngine, Template};
 use crate::models::{Gender, RenderContext, TemplateEntity};
+use crate::parser::Token;
 use std::borrow::Cow;
 
 #[test]
@@ -436,4 +437,107 @@ fn test_nested_properties_returning_proper_nouns() {
         PerspectiveEngine::render(&t, &ctx).expect("Failed to render template"),
         "Arthur draws Excalibur."
     );
+}
+
+#[test]
+fn test_inline_adjectives_ast_parsing() {
+    // 1. 2-part tag without owner: {Adjectives:Key}
+    let t1 = Template::compile("{glowing:sword}").expect("Failed to compile template");
+    if let Token::EntityRef {
+        key,
+        article,
+        p_type,
+        owner_key,
+        adjectives,
+        ..
+    } = &t1.tokens[0]
+    {
+        assert_eq!(key, "sword");
+        assert_eq!(article.as_deref(), None);
+        assert_eq!(p_type.as_deref(), None);
+        assert_eq!(owner_key.as_deref(), None);
+        assert_eq!(adjectives.as_deref(), Some("glowing ")); // Note: parser appends a trailing space natively
+    } else {
+        panic!("Expected EntityRef token");
+    }
+
+    // 2. 3-part tag with Article: {Article:Adjectives:Key}
+    let t2 = Template::compile("{The:rusty:shield}").expect("Failed to compile template");
+    if let Token::EntityRef {
+        key,
+        article,
+        p_type,
+        owner_key,
+        adjectives,
+        ..
+    } = &t2.tokens[0]
+    {
+        assert_eq!(key, "shield");
+        assert_eq!(article.as_deref(), Some("The"));
+        assert_eq!(p_type.as_deref(), None);
+        assert_eq!(owner_key.as_deref(), None);
+        assert_eq!(adjectives.as_deref(), Some("rusty "));
+    } else {
+        panic!("Expected EntityRef token");
+    }
+
+    // 3. 3-part tag with Case: {Adjectives:Key:Case}
+    let t3 = Template::compile("{big red:wolf:subj}").expect("Failed to compile template");
+    if let Token::EntityRef {
+        key,
+        article,
+        p_type,
+        owner_key,
+        adjectives,
+        ..
+    } = &t3.tokens[0]
+    {
+        assert_eq!(key, "wolf");
+        assert_eq!(article.as_deref(), None);
+        assert_eq!(p_type.as_deref(), Some("subj"));
+        assert_eq!(owner_key.as_deref(), None);
+        assert_eq!(adjectives.as_deref(), Some("big red "));
+    } else {
+        panic!("Expected EntityRef token");
+    }
+
+    // 4. Full 4-part tag without owner: {Article:Adjectives:Key:Case}
+    let t4 = Template::compile("{A:big red:wolf:subj}").expect("Failed to compile template");
+    if let Token::EntityRef {
+        key,
+        article,
+        p_type,
+        owner_key,
+        adjectives,
+        ..
+    } = &t4.tokens[0]
+    {
+        assert_eq!(key, "wolf");
+        assert_eq!(article.as_deref(), Some("A"));
+        assert_eq!(p_type.as_deref(), Some("subj"));
+        assert_eq!(owner_key.as_deref(), None);
+        assert_eq!(adjectives.as_deref(), Some("big red "));
+    } else {
+        panic!("Expected EntityRef token");
+    }
+
+    // 5. Sanity check: Ensure owner parsing still works! {Owner's Adjectives:Target}
+    let t5 = Template::compile("{Aldran's glowing:sword}").expect("Failed to compile template");
+    if let Token::EntityRef {
+        key,
+        article,
+        p_type,
+        owner_key,
+        adjectives,
+        ..
+    } = &t5.tokens[0]
+    {
+        assert_eq!(key, "sword");
+        assert_eq!(article.as_deref(), None);
+        assert_eq!(p_type.as_deref(), None);
+        assert_eq!(owner_key.as_deref(), Some("aldran"));
+        assert_eq!(adjectives.as_deref(), Some("glowing "));
+    } else {
+        panic!("Expected EntityRef token");
+    }
 }

--- a/src/tests/parser.rs
+++ b/src/tests/parser.rs
@@ -23,7 +23,7 @@ fn test_template_caching() {
         .get_or_compile(raw_text)
         .expect("Failed to compile template");
 
-    // Second call - CACHE HIT. The engine instantly returns the pre-compiled AST.
+    // Second call - CACHE HIT. The engine returns the pre-compiled AST.
     let template_2 = cache
         .get_or_compile(raw_text)
         .expect("Failed to compile template");

--- a/src/tests/resolution.rs
+++ b/src/tests/resolution.rs
@@ -2185,3 +2185,219 @@ fn test_is_same_entity_comparison() {
     // Should be false for different instances, even with completely identical data
     assert!(!is_same_entity(ref1, ref2));
 }
+
+#[test]
+fn test_resolve_target_adjective_synonyms() {
+    struct SynEntity {
+        name: &'static str,
+        adjs: &'static [&'static str],
+        syns: &'static [&'static str],
+    }
+    impl TemplateEntity for SynEntity {
+        fn contains_viewer(&self, _: &str) -> bool {
+            false
+        }
+        fn gender(&self) -> Gender {
+            Gender::Neutral
+        }
+        fn is_plural(&self) -> bool {
+            false
+        }
+        fn is_proper_noun_for(&self, _: &str) -> bool {
+            false
+        }
+        fn display_name_for<'a>(&'a self, _: &str) -> Cow<'a, str> {
+            Cow::Borrowed(self.name)
+        }
+        fn adjectives(&self) -> Option<&[&str]> {
+            Some(self.adjs)
+        }
+        fn adjective_synonyms(&self) -> Option<&[&str]> {
+            Some(self.syns)
+        }
+    }
+
+    let w1 = SynEntity {
+        name: "wolf",
+        adjs: &["large"],
+        syns: &["big", "huge"],
+    };
+    let ctx = RenderContext::new("viewer").with_entity("w1", &w1);
+
+    assert_eq!(ctx.resolve_target("large wolf").len(), 1);
+
+    assert_eq!(ctx.resolve_target("big wolf").len(), 1);
+    assert_eq!(ctx.resolve_target("huge wolf").len(), 1);
+    assert_eq!(ctx.resolve_target("small wolf").len(), 0);
+}
+
+#[test]
+fn test_resolve_target_adjective_synonyms_and_aliases() {
+    struct Boss {
+        name: &'static str,
+        aliases: &'static [&'static str],
+        adjectives: &'static [&'static str],
+        adjective_synonyms: &'static [&'static str],
+    }
+    impl TemplateEntity for Boss {
+        fn contains_viewer(&self, _: &str) -> bool {
+            false
+        }
+        fn gender(&self) -> Gender {
+            Gender::Male
+        }
+        fn is_plural(&self) -> bool {
+            false
+        }
+        fn is_proper_noun_for(&self, _: &str) -> bool {
+            true
+        }
+        fn display_name_for<'a>(&'a self, _: &str) -> Cow<'a, str> {
+            Cow::Borrowed(self.name)
+        }
+        fn aliases(&self) -> Option<&[&str]> {
+            Some(self.aliases)
+        }
+        fn adjectives(&self) -> Option<&[&str]> {
+            Some(self.adjectives)
+        }
+        fn adjective_synonyms(&self) -> Option<&[&str]> {
+            Some(self.adjective_synonyms)
+        }
+    }
+
+    let aldran = Boss {
+        name: "Aldran",
+        aliases: &["dark lord", "boss"],
+        adjectives: &["angry", "tall"],
+        adjective_synonyms: &["furious", "giant"],
+    };
+
+    let ctx = RenderContext::new("viewer").with_entity("aldran", &aldran);
+
+    // 1. Adjective synonym + Alias
+    assert_eq!(ctx.resolve_target("furious dark lord").len(), 1);
+    assert_eq!(ctx.resolve_target("giant boss").len(), 1);
+
+    // 2. Canonical adjective + Alias (sanity check)
+    assert_eq!(ctx.resolve_target("angry boss").len(), 1);
+
+    // 3. Adjective synonym + canonical name
+    assert_eq!(ctx.resolve_target("furious Aldran").len(), 1);
+
+    // 4. Missing synonym fails
+    assert_eq!(ctx.resolve_target("short boss").len(), 0);
+}
+
+#[test]
+fn test_resolve_target_adjective_partial_disambiguation() {
+    struct AdjEntity {
+        name: &'static str,
+        adjs: &'static [&'static str],
+    }
+    impl TemplateEntity for AdjEntity {
+        fn contains_viewer(&self, _: &str) -> bool {
+            false
+        }
+        fn gender(&self) -> Gender {
+            Gender::Neutral
+        }
+        fn is_plural(&self) -> bool {
+            false
+        }
+        fn is_proper_noun_for(&self, _: &str) -> bool {
+            false
+        }
+        fn display_name_for<'a>(&'a self, _: &str) -> Cow<'a, str> {
+            Cow::Borrowed(self.name)
+        }
+        fn adjectives(&self) -> Option<&[&str]> {
+            Some(self.adjs)
+        }
+    }
+
+    let w1 = AdjEntity {
+        name: "wolf",
+        adjs: &["large", "red"],
+    };
+    let w2 = AdjEntity {
+        name: "wolf",
+        adjs: &["large", "red"],
+    };
+    let w3 = AdjEntity {
+        name: "wolf",
+        adjs: &["large", "brown"],
+    };
+
+    let ctx = RenderContext::new("viewer")
+        .with_entity("w1", &w1)
+        .with_entity("w2", &w2)
+        .with_entity("w3", &w3)
+        .with_lookahead(true); // Enable lookahead to seed the ordinals
+
+    let cache = TemplateCache::new(100);
+    let t = cache
+        .get_or_compile("{*A:w1:subj}, {*a:w2:subj}, and {*a:w3:subj} arrive.")
+        .unwrap();
+    PerspectiveEngine::render(&t, &ctx).unwrap();
+
+    assert_eq!(ctx.resolve_target("the first red wolf").len(), 1);
+    assert_eq!(ctx.resolve_target("the first red wolf")[0].key, "w1");
+
+    assert_eq!(ctx.resolve_target("the second red wolf").len(), 1);
+    assert_eq!(ctx.resolve_target("the second red wolf")[0].key, "w2");
+
+    assert_eq!(ctx.resolve_target("the brown wolf").len(), 1);
+    assert_eq!(ctx.resolve_target("the brown wolf")[0].key, "w3");
+}
+
+#[test]
+fn test_target_cache_invalidation() {
+    let goblin = MockEntity {
+        id: "mob_1".to_string(),
+        name: "goblin".to_string(),
+        gender: Gender::Neutral,
+        is_plural: false,
+        is_proper_noun: false,
+    };
+
+    let ctx = RenderContext::new("viewer").with_entity("g1", &goblin);
+
+    // 1. Initial resolution populates the cache
+    assert_eq!(ctx.target_cache.borrow().len(), 0);
+    let _ = ctx.resolve_target("goblin");
+    assert_eq!(ctx.target_cache.borrow().len(), 1);
+
+    // 2. clear_anaphora clears the cache
+    ctx.clear_anaphora();
+    assert_eq!(ctx.target_cache.borrow().len(), 0);
+
+    // 3. with_last_mentioned clears the cache
+    let _ = ctx.resolve_target("goblin");
+    let ctx = ctx.with_last_mentioned("g1");
+    assert_eq!(ctx.target_cache.borrow().len(), 0);
+
+    // 4. pin_anaphora/forget_anaphora clears the cache
+    let _ = ctx.resolve_target("goblin");
+    ctx.pin_anaphora("g1");
+    assert_eq!(ctx.target_cache.borrow().len(), 0);
+
+    let _ = ctx.resolve_target("goblin");
+    ctx.forget_anaphora("g1");
+    assert_eq!(ctx.target_cache.borrow().len(), 0);
+
+    // 5. Structural builder methods clear the cache
+    let _ = ctx.resolve_target("goblin");
+    let ctx = ctx.with_viewer("new_viewer");
+    assert_eq!(ctx.target_cache.borrow().len(), 0);
+
+    let _ = ctx.resolve_target("goblin");
+    let ctx = ctx.with_strict_diacritics(true);
+    assert_eq!(ctx.target_cache.borrow().len(), 0);
+
+    // 6. Explicit clear_target_cache
+    let _ = ctx.resolve_target("goblin");
+    assert_eq!(ctx.target_cache.borrow().len(), 1);
+    ctx.clear_target_cache();
+    assert_eq!(ctx.target_cache.borrow().len(), 0);
+}

--- a/src/tests/resolution.rs
+++ b/src/tests/resolution.rs
@@ -864,7 +864,7 @@ fn test_resolve_target_dynamic_adjective_mutation() {
     // 2. Mutate state: The wolf loses a leg!
     let ctx_injured = ctx.with_entity("target", &injured_wolf);
 
-    // Without clearing anaphora, target resolution should instantly recognize the new data-driven adjective!
+    // Without clearing anaphora, target resolution should recognize the new data-driven adjective.
     let m1 = ctx_injured.resolve_target("three-legged wolf");
     assert_eq!(m1.len(), 1);
     assert_eq!(m1[0].key, "target");
@@ -2338,8 +2338,8 @@ fn test_resolve_target_adjective_partial_disambiguation() {
     let cache = TemplateCache::new(100);
     let t = cache
         .get_or_compile("{*A:w1:subj}, {*a:w2:subj}, and {*a:w3:subj} arrive.")
-        .unwrap();
-    PerspectiveEngine::render(&t, &ctx).unwrap();
+        .expect("Failed to compile template");
+    PerspectiveEngine::render(&t, &ctx).expect("Failed to render template");
 
     assert_eq!(ctx.resolve_target("the first red wolf").len(), 1);
     assert_eq!(ctx.resolve_target("the first red wolf")[0].key, "w1");

--- a/src/tests/resolution.rs
+++ b/src/tests/resolution.rs
@@ -2352,6 +2352,103 @@ fn test_resolve_target_adjective_partial_disambiguation() {
 }
 
 #[test]
+fn test_resolve_target_inline_adjectives_without_owner() {
+    let sword = MockEntity {
+        id: "item_1".into(),
+        name: "sword".into(),
+        gender: Gender::Neutral,
+        is_plural: false,
+        is_proper_noun: false,
+    };
+
+    let cache = TemplateCache::new(100);
+    let ctx = RenderContext::new("viewer").with_entity("target", &sword);
+
+    // 1. With an article ({A:adjectives:target:case})
+    let t1 = cache
+        .get_or_compile("{*A:glowing:target:obj} [target:hum].")
+        .expect("Failed to compile template");
+    assert_eq!(
+        PerspectiveEngine::render(&t1, &ctx).expect("Failed to render template"),
+        "A glowing sword hums."
+    );
+
+    let m1 = ctx.resolve_target("glowing sword");
+    assert_eq!(m1.len(), 1);
+
+    // 2. Without an article ({adjectives:target})
+    ctx.clear_anaphora();
+    let t2 = cache
+        .get_or_compile("You see a {glowing:target}.")
+        .expect("Failed to compile template");
+    assert_eq!(
+        PerspectiveEngine::render(&t2, &ctx).expect("Failed to render template"),
+        "You see a glowing sword."
+    );
+
+    let m2 = ctx.resolve_target("glowing sword");
+    assert_eq!(m2.len(), 1);
+}
+
+#[test]
+fn test_target_resolution_resolved_name_fast_path() {
+    struct AdjEntity {
+        name: &'static str,
+        adjs: &'static [&'static str],
+    }
+    impl TemplateEntity for AdjEntity {
+        fn contains_viewer(&self, _: &str) -> bool {
+            false
+        }
+        fn gender(&self) -> Gender {
+            Gender::Neutral
+        }
+        fn is_plural(&self) -> bool {
+            false
+        }
+        fn is_proper_noun_for(&self, _: &str) -> bool {
+            false
+        }
+        fn display_name_for<'a>(&'a self, _: &str) -> Cow<'a, str> {
+            Cow::Borrowed(self.name)
+        }
+        fn adjectives(&self) -> Option<&[&str]> {
+            Some(self.adjs)
+        }
+    }
+
+    let w1 = AdjEntity {
+        name: "wolf",
+        adjs: &["tall", "red"],
+    };
+    let w2 = AdjEntity {
+        name: "wolf",
+        adjs: &["brown"],
+    };
+
+    let ctx = RenderContext::new("viewer")
+        .with_entity("w1", &w1)
+        .with_entity("w2", &w2)
+        .with_lookahead(true);
+
+    let cache = TemplateCache::new(100);
+    let t = cache
+        .get_or_compile("{*A:w1:subj} and {*a:w2:subj} arrive.")
+        .expect("Failed to compile template");
+    PerspectiveEngine::render(&t, &ctx).expect("Failed to render template");
+
+    // 1. Sanity check: The fast path should allow exact matches on the generated "red wolf"
+    assert_eq!(ctx.resolve_target("red wolf").len(), 1);
+    assert_eq!(ctx.resolve_target("red wolf")[0].key, "w1");
+
+    // 2. Edge Case: Verify the fast-path noun ("red wolf") safely integrates with leftover
+    //    canonical adjectives ("tall") that were not used during disambiguation!
+    let matches = ctx.resolve_target("tall red wolf");
+    assert_eq!(matches.len(), 1);
+    assert_eq!(matches[0].key, "w1");
+}
+
+#[test]
 fn test_target_cache_invalidation() {
     let goblin = MockEntity {
         id: "mob_1".to_string(),

--- a/src/tests/unified.rs
+++ b/src/tests/unified.rs
@@ -1731,13 +1731,13 @@ fn test_unified_possessives_with_long_descriptions_on_proper_nouns() {
         "Arthur the Elder's glowing Excalibur of the Lake."
     );
 
-    // 2. Drop possessive override (@) correctly drops the long owner and the adjectives
+    // 2. Drop possessive override (@) correctly drops the long owner but preserves adjectives
     let t2 = cache
         .get_or_compile("{A1's glowing @e1:obj}.")
         .expect("Failed to compile template");
     assert_eq!(
         PerspectiveEngine::render(&t2, &ctx).expect("Failed to render template"),
-        "Excalibur of the Lake."
+        "Glowing Excalibur of the Lake."
     );
 }
 


### PR DESCRIPTION
- Introduced `adjective_synonyms` method in `TemplateEntity` to allow for fuzzy matching of adjectives during target resolution.
- Implemented adjective disambiguation logic in `PerspectiveEngine` to prepend unique adjectives for entities with overlapping descriptors.
- Added support for limiting the number of adjectives evaluated for disambiguation to prevent performance issues.
- Updated `RenderContext` to include auto-clear functionality for anaphora memory after rendering.
- Enhanced tests to cover new adjective disambiguation features and synonym handling.